### PR TITLE
Chore: Centralize workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ resolver = "3"
   # Kaspa dependencies
   kaspa-addresses           = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-consensus-core      = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-  kaspa-hashes              = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-core                = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-grpc-client         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-hashes              = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-notify              = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-rpc-core            = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
   kaspa-testing-integration = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
@@ -70,7 +70,7 @@ resolver = "3"
   vprogs-core-atomics                             = { path = "core/atomics" }
   vprogs-core-macros                              = { path = "core/macros" }
   vprogs-core-types                               = { path = "core/types" }
-  vprogs-node-l1-bridge                             = { path = "node/l1-bridge" }
+  vprogs-node-l1-bridge                           = { path = "node/l1-bridge" }
   vprogs-node-test-suite                          = { path = "node/test-suite" }
   vprogs-node-vm                                  = { path = "node/vm" }
   vprogs-scheduling-execution-workers             = { path = "scheduling/execution-workers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,4 @@
 [workspace]
-resolver = "3"
-
-members = [
-  "core/*",
-  "node/*",
-  "scheduling/*",
-  "state/*",
-  "storage/*",
-  "transaction-runtime/*",
-]
-
 default-members = [
   "core/*",
   "node/*",
@@ -18,5 +7,100 @@ default-members = [
   "storage/*",
   "transaction-runtime/*",
 ]
-
 exclude = []
+members = [
+  "core/*",
+  "node/*",
+  "scheduling/*",
+  "state/*",
+  "storage/*",
+  "transaction-runtime/*",
+]
+resolver = "3"
+
+  [workspace.package]
+  edition = "2021"
+  version = "0.1.0"
+
+  [workspace.dependencies]
+  # External dependencies
+  arc-swap = "1.7"
+  borsh = { version = "1.6.0", features = ["derive"] }
+  crossbeam-deque = "0.8.6"
+  crossbeam-queue = "0.3.12"
+  crossbeam-utils = "0.8.21"
+  fastrand = "2.3.0"
+  futures = "0.3.31"
+  intrusive-collections = "0.9.7"
+  log = "0.4"
+  num_cpus = "1.17.0"
+  proc-macro2 = "1.0.103"
+  quote = "1.0.42"
+  rocksdb = { version = "0.24.0", default-features = false, features = [
+    "lz4",
+    "zstd",
+    "snappy",
+    "zlib",
+    "bzip2",
+    "jemalloc",
+    "mt_static",
+  ] }
+  syn = { version = "2.0.111", features = ["full"] }
+  tap = "1.0.1"
+  tempfile = "3.23.0"
+  thiserror = "2"
+  tokio = { version = "1", features = ["rt", "sync"] }
+  tokio-util = "0.7.17"
+  workflow-core = "0.18.0"
+
+  # Kaspa dependencies
+  kaspa-addresses           = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-consensus-core      = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-hashes              = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-core                = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-grpc-client         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-notify              = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-rpc-core            = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-testing-integration = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-wrpc-client         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspa-wrpc-server         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+  kaspad                    = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
+
+  # Internal dependencies
+  vprogs-core-atomics                             = { path = "core/atomics" }
+  vprogs-core-macros                              = { path = "core/macros" }
+  vprogs-core-types                               = { path = "core/types" }
+  vprogs-node-l1-bridge                             = { path = "node/l1-bridge" }
+  vprogs-node-test-suite                          = { path = "node/test-suite" }
+  vprogs-node-vm                                  = { path = "node/vm" }
+  vprogs-scheduling-execution-workers             = { path = "scheduling/execution-workers" }
+  vprogs-scheduling-scheduler                     = { path = "scheduling/scheduler" }
+  vprogs-scheduling-test-suite                    = { path = "scheduling/test-suite" }
+  vprogs-state-metadata                           = { path = "state/metadata" }
+  vprogs-state-ptr-latest                         = { path = "state/ptr-latest" }
+  vprogs-state-ptr-rollback                       = { path = "state/ptr-rollback" }
+  vprogs-state-space                              = { path = "state/space" }
+  vprogs-state-version                            = { path = "state/version" }
+  vprogs-storage-manager                          = { path = "storage/manager" }
+  vprogs-storage-rocksdb-store                    = { path = "storage/rocksdb-store" }
+  vprogs-storage-types                            = { path = "storage/types" }
+  vprogs-transaction-runtime                      = { path = "transaction-runtime/transaction-runtime" }
+  vprogs-transaction-runtime-address              = { path = "transaction-runtime/address" }
+  vprogs-transaction-runtime-auth-context         = { path = "transaction-runtime/auth-context" }
+  vprogs-transaction-runtime-authenticated-data   = { path = "transaction-runtime/authenticated-data" }
+  vprogs-transaction-runtime-builtin-capabilities = { path = "transaction-runtime/builtin-capabilities" }
+  vprogs-transaction-runtime-data                 = { path = "transaction-runtime/data" }
+  vprogs-transaction-runtime-data-context         = { path = "transaction-runtime/data-context" }
+  vprogs-transaction-runtime-error                = { path = "transaction-runtime/error" }
+  vprogs-transaction-runtime-instruction          = { path = "transaction-runtime/instruction" }
+  vprogs-transaction-runtime-lock                 = { path = "transaction-runtime/lock" }
+  vprogs-transaction-runtime-object-access        = { path = "transaction-runtime/object-access" }
+  vprogs-transaction-runtime-object-id            = { path = "transaction-runtime/object-id" }
+  vprogs-transaction-runtime-program              = { path = "transaction-runtime/program" }
+  vprogs-transaction-runtime-program-arg          = { path = "transaction-runtime/program-arg" }
+  vprogs-transaction-runtime-program-context      = { path = "transaction-runtime/program-context" }
+  vprogs-transaction-runtime-program-type         = { path = "transaction-runtime/program-type" }
+  vprogs-transaction-runtime-pubkey               = { path = "transaction-runtime/pubkey" }
+  vprogs-transaction-runtime-signature-lock       = { path = "transaction-runtime/signature-lock" }
+  vprogs-transaction-runtime-transaction          = { path = "transaction-runtime/transaction" }
+  vprogs-transaction-runtime-transaction-effects  = { path = "transaction-runtime/transaction-effects" }

--- a/core/atomics/Cargo.toml
+++ b/core/atomics/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-core-atomics"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-core-atomics"
+version.workspace = true
 
 [dependencies]
-futures    = "0.3.31"
-tokio-util = "0.7.17"
+futures.workspace    = true
+tokio-util.workspace = true

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-edition = "2021"
-name    = "vprogs-core-macros"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-core-macros"
+version.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.103"
-quote       = "1.0.42"
-syn         = { version = "2.0.111", features = ["full"] }
+proc-macro2.workspace = true
+quote.workspace       = true
+syn.workspace         = true

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-core-types"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-core-types"
+version.workspace = true
 
 [dependencies]
-borsh = { version = "1.6.0", features = ["derive"] }
+borsh.workspace = true

--- a/node/l1-bridge/Cargo.toml
+++ b/node/l1-bridge/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-edition = "2021"
-name    = "vprogs-node-l1-bridge"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-node-l1-bridge"
+version.workspace = true
 
 [dependencies]
-arc-swap             = "1"
-crossbeam-queue      = "0.3.12"
-futures              = "0.3"
-kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-hashes         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-notify         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-rpc-core       = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-wrpc-client    = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-log                  = "0.4"
-tap                  = "1.0.1"
-thiserror            = "2"
-tokio                = { version = "1", features = ["rt", "sync"] }
-vprogs-core-macros   = { path = "../../core/macros" }
-workflow-core        = "0.18.0"
+arc-swap.workspace             = true
+crossbeam-queue.workspace      = true
+futures.workspace              = true
+kaspa-consensus-core.workspace = true
+kaspa-hashes.workspace         = true
+kaspa-notify.workspace         = true
+kaspa-rpc-core.workspace       = true
+kaspa-wrpc-client.workspace    = true
+log.workspace                  = true
+tap.workspace                  = true
+thiserror.workspace            = true
+tokio.workspace                = true
+vprogs-core-macros.workspace   = true
+workflow-core.workspace        = true
 
 [dev-dependencies]
-tokio                  = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-vprogs-node-test-suite = { path = "../test-suite" }
+tokio                            = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+vprogs-node-test-suite.workspace = true

--- a/node/test-suite/Cargo.toml
+++ b/node/test-suite/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-edition = "2021"
-name    = "vprogs-node-test-suite"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-node-test-suite"
+version.workspace = true
 
 [dependencies]
-futures                   = "0.3"
-kaspa-addresses           = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-consensus-core      = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-core                = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-grpc-client         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-rpc-core            = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-testing-integration = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspa-wrpc-server         = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-kaspad                    = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "master" }
-tokio                     = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-vprogs-node-l1-bridge     = { path = "../l1-bridge" }
+futures.workspace                   = true
+kaspa-addresses.workspace           = true
+kaspa-consensus-core.workspace      = true
+kaspa-core.workspace                = true
+kaspa-grpc-client.workspace         = true
+kaspa-rpc-core.workspace            = true
+kaspa-testing-integration.workspace = true
+kaspa-wrpc-server.workspace         = true
+kaspad.workspace                    = true
+tokio                               = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+vprogs-node-l1-bridge.workspace     = true

--- a/node/vm/Cargo.toml
+++ b/node/vm/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-edition = "2021"
-name    = "vprogs-node-vm"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-node-vm"
+version.workspace = true
 
 [dependencies]
-vprogs-scheduling-scheduler                    = { path = "../../scheduling/scheduler" }
-vprogs-state-space                             = { path = "../../state/space" }
-vprogs-storage-types                           = { path = "../../storage/types" }
-vprogs-transaction-runtime                     = { path = "../../transaction-runtime/transaction-runtime" }
-vprogs-transaction-runtime-error               = { path = "../../transaction-runtime/error" }
-vprogs-transaction-runtime-object-access       = { path = "../../transaction-runtime/object-access" }
-vprogs-transaction-runtime-object-id           = { path = "../../transaction-runtime/object-id" }
-vprogs-transaction-runtime-transaction         = { path = "../../transaction-runtime/transaction" }
-vprogs-transaction-runtime-transaction-effects = { path = "../../transaction-runtime/transaction-effects" }
+vprogs-scheduling-scheduler.workspace                    = true
+vprogs-state-space.workspace                             = true
+vprogs-storage-types.workspace                           = true
+vprogs-transaction-runtime.workspace                     = true
+vprogs-transaction-runtime-error.workspace               = true
+vprogs-transaction-runtime-object-access.workspace       = true
+vprogs-transaction-runtime-object-id.workspace           = true
+vprogs-transaction-runtime-transaction.workspace         = true
+vprogs-transaction-runtime-transaction-effects.workspace = true

--- a/scheduling/execution-workers/Cargo.toml
+++ b/scheduling/execution-workers/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-edition = "2021"
-name    = "vprogs-scheduling-execution-workers"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-scheduling-execution-workers"
+version.workspace = true
 
 [dependencies]
-crossbeam-deque       = "0.8.6"
-crossbeam-queue       = "0.3.12"
-crossbeam-utils       = "0.8.21"
-fastrand              = "2.3.0"
-intrusive-collections = "0.9.7"
-tap                   = "1.0.1"
-vprogs-core-atomics   = { path = "../../core/atomics" }
-vprogs-core-macros    = { path = "../../core/macros" }
+crossbeam-deque.workspace       = true
+crossbeam-queue.workspace       = true
+crossbeam-utils.workspace       = true
+fastrand.workspace              = true
+intrusive-collections.workspace = true
+tap.workspace                   = true
+vprogs-core-atomics.workspace   = true
+vprogs-core-macros.workspace    = true

--- a/scheduling/scheduler/Cargo.toml
+++ b/scheduling/scheduler/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-edition = "2021"
-name    = "vprogs-scheduling-scheduler"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-scheduling-scheduler"
+version.workspace = true
 
 [dependencies]
-arc-swap                            = "1.7"
-crossbeam-deque                     = "0.8.6"
-crossbeam-queue                     = "0.3.12"
-num_cpus                            = "1.17.0"
-tap                                 = "1.0.1"
-tokio                               = { version = "1.48.0", features = ["rt", "sync"] }
-vprogs-core-atomics                 = { path = "../../core/atomics" }
-vprogs-core-macros                  = { path = "../../core/macros" }
-vprogs-core-types                   = { path = "../../core/types" }
-vprogs-scheduling-execution-workers = { path = "../execution-workers" }
-vprogs-state-metadata               = { path = "../../state/metadata" }
-vprogs-state-ptr-latest             = { path = "../../state/ptr-latest" }
-vprogs-state-ptr-rollback           = { path = "../../state/ptr-rollback" }
-vprogs-state-space                  = { path = "../../state/space" }
-vprogs-state-version                = { path = "../../state/version" }
-vprogs-storage-manager              = { path = "../../storage/manager" }
-vprogs-storage-types                = { path = "../../storage/types" }
+arc-swap.workspace                            = true
+crossbeam-deque.workspace                     = true
+crossbeam-queue.workspace                     = true
+num_cpus.workspace                            = true
+tap.workspace                                 = true
+tokio.workspace                               = true
+vprogs-core-atomics.workspace                 = true
+vprogs-core-macros.workspace                  = true
+vprogs-core-types.workspace                   = true
+vprogs-scheduling-execution-workers.workspace = true
+vprogs-state-metadata.workspace               = true
+vprogs-state-ptr-latest.workspace             = true
+vprogs-state-ptr-rollback.workspace           = true
+vprogs-state-space.workspace                  = true
+vprogs-state-version.workspace                = true
+vprogs-storage-manager.workspace              = true
+vprogs-storage-types.workspace                = true

--- a/scheduling/test-suite/Cargo.toml
+++ b/scheduling/test-suite/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-edition = "2021"
-name    = "vprogs-scheduling-test-suite"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-scheduling-test-suite"
+version.workspace = true
 
 [dependencies]
-tempfile                     = "3.23.0"
-vprogs-core-types            = { path = "../../core/types" }
-vprogs-scheduling-scheduler  = { path = "../scheduler" }
-vprogs-state-metadata        = { path = "../../state/metadata" }
-vprogs-state-ptr-rollback    = { path = "../../state/ptr-rollback" }
-vprogs-state-space           = { path = "../../state/space" }
-vprogs-state-version         = { path = "../../state/version" }
-vprogs-storage-manager       = { path = "../../storage/manager" }
-vprogs-storage-rocksdb-store = { path = "../../storage/rocksdb-store" }
-vprogs-storage-types         = { path = "../../storage/types" }
+tempfile.workspace                     = true
+vprogs-core-types.workspace            = true
+vprogs-scheduling-scheduler.workspace  = true
+vprogs-state-metadata.workspace        = true
+vprogs-state-ptr-rollback.workspace    = true
+vprogs-state-space.workspace           = true
+vprogs-state-version.workspace         = true
+vprogs-storage-manager.workspace       = true
+vprogs-storage-rocksdb-store.workspace = true
+vprogs-storage-types.workspace         = true

--- a/state/metadata/Cargo.toml
+++ b/state/metadata/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-state-metadata"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-state-metadata"
+version.workspace = true
 
 [dependencies]
-vprogs-state-space   = { path = "../space" }
-vprogs-storage-types = { path = "../../storage/types" }
+vprogs-state-space.workspace   = true
+vprogs-storage-types.workspace = true

--- a/state/ptr-latest/Cargo.toml
+++ b/state/ptr-latest/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-edition = "2021"
-name    = "vprogs-state-ptr-latest"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-state-ptr-latest"
+version.workspace = true
 
 [dependencies]
-vprogs-core-types    = { path = "../../core/types" }
-vprogs-state-space   = { path = "../space" }
-vprogs-storage-types = { path = "../../storage/types" }
+vprogs-core-types.workspace    = true
+vprogs-state-space.workspace   = true
+vprogs-storage-types.workspace = true

--- a/state/ptr-rollback/Cargo.toml
+++ b/state/ptr-rollback/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-edition = "2021"
-name    = "vprogs-state-ptr-rollback"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-state-ptr-rollback"
+version.workspace = true
 
 [dependencies]
-vprogs-core-types      = { path = "../../core/types" }
-vprogs-state-space     = { path = "../space" }
-vprogs-storage-manager = { path = "../../storage/manager" }
-vprogs-storage-types   = { path = "../../storage/types" }
+vprogs-core-types.workspace      = true
+vprogs-state-space.workspace     = true
+vprogs-storage-manager.workspace = true
+vprogs-storage-types.workspace   = true

--- a/state/space/Cargo.toml
+++ b/state/space/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-edition = "2021"
-name    = "vprogs-state-space"
-version = "0.1.0"
-
-[dependencies]
+edition.workspace = true
+name              = "vprogs-state-space"
+version.workspace = true

--- a/state/version/Cargo.toml
+++ b/state/version/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-edition = "2021"
-name    = "vprogs-state-version"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-state-version"
+version.workspace = true
 
 [dependencies]
-tap                       = "1.0.1"
-vprogs-core-types         = { path = "../../core/types" }
-vprogs-state-ptr-latest   = { path = "../ptr-latest" }
-vprogs-state-ptr-rollback = { path = "../ptr-rollback" }
-vprogs-state-space        = { path = "../space" }
-vprogs-storage-manager    = { path = "../../storage/manager" }
-vprogs-storage-types      = { path = "../../storage/types" }
+tap.workspace                       = true
+vprogs-core-types.workspace         = true
+vprogs-state-ptr-latest.workspace   = true
+vprogs-state-ptr-rollback.workspace = true
+vprogs-state-space.workspace        = true
+vprogs-storage-manager.workspace    = true
+vprogs-storage-types.workspace      = true

--- a/storage/manager/Cargo.toml
+++ b/storage/manager/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-edition = "2021"
-name    = "vprogs-storage-manager"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-storage-manager"
+version.workspace = true
 
 [dependencies]
-crossbeam-queue      = "0.3.12"
-crossbeam-utils      = "0.8.21"
-vprogs-core-macros   = { path = "../../core/macros" }
-vprogs-storage-types = { path = "../types" }
+crossbeam-queue.workspace      = true
+crossbeam-utils.workspace      = true
+vprogs-core-macros.workspace   = true
+vprogs-storage-types.workspace = true

--- a/storage/rocksdb-store/Cargo.toml
+++ b/storage/rocksdb-store/Cargo.toml
@@ -1,19 +1,11 @@
 [package]
-edition = "2021"
-name    = "vprogs-storage-rocksdb-store"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-storage-rocksdb-store"
+version.workspace = true
 
 [dependencies]
-num_cpus = "1.17.0"
-rocksdb = { version = "0.24.0", default-features = false, features = [
-  "lz4",
-  "zstd",
-  "snappy",
-  "zlib",
-  "bzip2",
-  "jemalloc",
-  "mt_static",
-] }
-tap = "1.0.1"
-vprogs-state-space = { path = "../../state/space" }
-vprogs-storage-types = { path = "../types" }
+num_cpus.workspace             = true
+rocksdb.workspace              = true
+tap.workspace                  = true
+vprogs-state-space.workspace   = true
+vprogs-storage-types.workspace = true

--- a/storage/types/Cargo.toml
+++ b/storage/types/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-edition = "2021"
-name    = "vprogs-storage-types"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-storage-types"
+version.workspace = true

--- a/transaction-runtime/address/Cargo.toml
+++ b/transaction-runtime/address/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-address"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-address"
+version.workspace = true
 
 [dependencies]
-borsh = "1.6.0"
+borsh.workspace = true

--- a/transaction-runtime/auth-context/Cargo.toml
+++ b/transaction-runtime/auth-context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-auth-context"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-auth-context"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-pubkey = { path = "../pubkey" }
+vprogs-transaction-runtime-pubkey.workspace = true

--- a/transaction-runtime/authenticated-data/Cargo.toml
+++ b/transaction-runtime/authenticated-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-authenticated-data"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-authenticated-data"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-data = { path = "../data" }
+vprogs-transaction-runtime-data.workspace = true

--- a/transaction-runtime/builtin-capabilities/Cargo.toml
+++ b/transaction-runtime/builtin-capabilities/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-builtin-capabilities"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-builtin-capabilities"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address = { path = "../address" }
-vprogs-transaction-runtime-data    = { path = "../data" }
+vprogs-transaction-runtime-address.workspace = true
+vprogs-transaction-runtime-data.workspace    = true

--- a/transaction-runtime/data-context/Cargo.toml
+++ b/transaction-runtime/data-context/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-data-context"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-data-context"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address            = { path = "../address" }
-vprogs-transaction-runtime-authenticated-data = { path = "../authenticated-data" }
-vprogs-transaction-runtime-error              = { path = "../error" }
+vprogs-transaction-runtime-address.workspace            = true
+vprogs-transaction-runtime-authenticated-data.workspace = true
+vprogs-transaction-runtime-error.workspace              = true

--- a/transaction-runtime/data/Cargo.toml
+++ b/transaction-runtime/data/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-data"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-data"
+version.workspace = true
 
 [dependencies]
-borsh                              = "1.6.0"
-vprogs-transaction-runtime-address = { path = "../address" }
+borsh.workspace                              = true
+vprogs-transaction-runtime-address.workspace = true

--- a/transaction-runtime/error/Cargo.toml
+++ b/transaction-runtime/error/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-error"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-error"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address = { path = "../address" }
+vprogs-transaction-runtime-address.workspace = true

--- a/transaction-runtime/instruction/Cargo.toml
+++ b/transaction-runtime/instruction/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-instruction"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-instruction"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address     = { path = "../address" }
-vprogs-transaction-runtime-program-arg = { path = "../program-arg" }
+vprogs-transaction-runtime-address.workspace     = true
+vprogs-transaction-runtime-program-arg.workspace = true

--- a/transaction-runtime/lock/Cargo.toml
+++ b/transaction-runtime/lock/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-lock"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-lock"
+version.workspace = true
 
 [dependencies]
-borsh                                           = "1.6.0"
-vprogs-transaction-runtime-auth-context         = { path = "../auth-context" }
-vprogs-transaction-runtime-builtin-capabilities = { path = "../builtin-capabilities" }
-vprogs-transaction-runtime-data                 = { path = "../data" }
-vprogs-transaction-runtime-signature-lock       = { path = "../signature-lock" }
+borsh.workspace                                           = true
+vprogs-transaction-runtime-auth-context.workspace         = true
+vprogs-transaction-runtime-builtin-capabilities.workspace = true
+vprogs-transaction-runtime-data.workspace                 = true
+vprogs-transaction-runtime-signature-lock.workspace       = true

--- a/transaction-runtime/object-access/Cargo.toml
+++ b/transaction-runtime/object-access/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-object-access"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-object-access"
+version.workspace = true
 
 [dependencies]
-vprogs-core-types                    = { path = "../../core/types" }
-vprogs-transaction-runtime-object-id = { path = "../object-id" }
+vprogs-core-types.workspace                    = true
+vprogs-transaction-runtime-object-id.workspace = true

--- a/transaction-runtime/object-id/Cargo.toml
+++ b/transaction-runtime/object-id/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-object-id"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-object-id"
+version.workspace = true
 
 [dependencies]
-borsh                              = "1.6.0"
-vprogs-transaction-runtime-address = { path = "../address" }
+borsh.workspace                              = true
+vprogs-transaction-runtime-address.workspace = true

--- a/transaction-runtime/program-arg/Cargo.toml
+++ b/transaction-runtime/program-arg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-program-arg"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-program-arg"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address = { path = "../address" }
+vprogs-transaction-runtime-address.workspace = true

--- a/transaction-runtime/program-context/Cargo.toml
+++ b/transaction-runtime/program-context/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-program-context"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-program-context"
+version.workspace = true
 
 [dependencies]
-vprogs-transaction-runtime-address            = { path = "../address" }
-vprogs-transaction-runtime-authenticated-data = { path = "../authenticated-data" }
-vprogs-transaction-runtime-data-context       = { path = "../data-context" }
-vprogs-transaction-runtime-error              = { path = "../error" }
+vprogs-transaction-runtime-address.workspace            = true
+vprogs-transaction-runtime-authenticated-data.workspace = true
+vprogs-transaction-runtime-data-context.workspace       = true
+vprogs-transaction-runtime-error.workspace              = true

--- a/transaction-runtime/program-type/Cargo.toml
+++ b/transaction-runtime/program-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-program-type"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-program-type"
+version.workspace = true
 
 [dependencies]
-borsh = "1.6.0"
+borsh.workspace = true

--- a/transaction-runtime/program/Cargo.toml
+++ b/transaction-runtime/program/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-program"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-program"
+version.workspace = true
 
 [dependencies]
-borsh                                   = "1.6.0"
-vprogs-transaction-runtime-program-type = { path = "../program-type" }
+borsh.workspace                                   = true
+vprogs-transaction-runtime-program-type.workspace = true

--- a/transaction-runtime/pubkey/Cargo.toml
+++ b/transaction-runtime/pubkey/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-pubkey"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-pubkey"
+version.workspace = true

--- a/transaction-runtime/signature-lock/Cargo.toml
+++ b/transaction-runtime/signature-lock/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-signature-lock"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-signature-lock"
+version.workspace = true
 
 [dependencies]
-borsh                                           = "1.6.0"
-vprogs-transaction-runtime-auth-context         = { path = "../auth-context" }
-vprogs-transaction-runtime-builtin-capabilities = { path = "../builtin-capabilities" }
-vprogs-transaction-runtime-pubkey               = { path = "../pubkey" }
+borsh.workspace                                           = true
+vprogs-transaction-runtime-auth-context.workspace         = true
+vprogs-transaction-runtime-builtin-capabilities.workspace = true
+vprogs-transaction-runtime-pubkey.workspace               = true

--- a/transaction-runtime/transaction-effects/Cargo.toml
+++ b/transaction-runtime/transaction-effects/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-transaction-effects"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-transaction-effects"
+version.workspace = true

--- a/transaction-runtime/transaction-runtime/Cargo.toml
+++ b/transaction-runtime/transaction-runtime/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime"
+version.workspace = true
 
 [dependencies]
-borsh                                          = "1.6.0"
-vprogs-core-types                              = { path = "../../core/types" }
-vprogs-scheduling-scheduler                    = { path = "../../scheduling/scheduler" }
-vprogs-state-space                             = { path = "../../state/space" }
-vprogs-storage-types                           = { path = "../../storage/types" }
-vprogs-transaction-runtime-address             = { path = "../address" }
-vprogs-transaction-runtime-auth-context        = { path = "../auth-context" }
-vprogs-transaction-runtime-authenticated-data  = { path = "../authenticated-data" }
-vprogs-transaction-runtime-data                = { path = "../data" }
-vprogs-transaction-runtime-data-context        = { path = "../data-context" }
-vprogs-transaction-runtime-error               = { path = "../error" }
-vprogs-transaction-runtime-instruction         = { path = "../instruction" }
-vprogs-transaction-runtime-lock                = { path = "../lock" }
-vprogs-transaction-runtime-object-id           = { path = "../object-id" }
-vprogs-transaction-runtime-program             = { path = "../program" }
-vprogs-transaction-runtime-pubkey              = { path = "../pubkey" }
-vprogs-transaction-runtime-transaction         = { path = "../transaction" }
-vprogs-transaction-runtime-transaction-effects = { path = "../transaction-effects" }
+borsh.workspace                                          = true
+vprogs-core-types.workspace                              = true
+vprogs-scheduling-scheduler.workspace                    = true
+vprogs-state-space.workspace                             = true
+vprogs-storage-types.workspace                           = true
+vprogs-transaction-runtime-address.workspace             = true
+vprogs-transaction-runtime-auth-context.workspace        = true
+vprogs-transaction-runtime-authenticated-data.workspace  = true
+vprogs-transaction-runtime-data.workspace                = true
+vprogs-transaction-runtime-data-context.workspace        = true
+vprogs-transaction-runtime-error.workspace               = true
+vprogs-transaction-runtime-instruction.workspace         = true
+vprogs-transaction-runtime-lock.workspace                = true
+vprogs-transaction-runtime-object-id.workspace           = true
+vprogs-transaction-runtime-program.workspace             = true
+vprogs-transaction-runtime-pubkey.workspace              = true
+vprogs-transaction-runtime-transaction.workspace         = true
+vprogs-transaction-runtime-transaction-effects.workspace = true

--- a/transaction-runtime/transaction/Cargo.toml
+++ b/transaction-runtime/transaction/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-edition = "2021"
-name    = "vprogs-transaction-runtime-transaction"
-version = "0.1.0"
+edition.workspace = true
+name              = "vprogs-transaction-runtime-transaction"
+version.workspace = true
 
 [dependencies]
-vprogs-core-types                        = { path = "../../core/types" }
-vprogs-transaction-runtime-instruction   = { path = "../instruction" }
-vprogs-transaction-runtime-object-access = { path = "../object-access" }
-vprogs-transaction-runtime-object-id     = { path = "../object-id" }
+vprogs-core-types.workspace                        = true
+vprogs-transaction-runtime-instruction.workspace   = true
+vprogs-transaction-runtime-object-access.workspace = true
+vprogs-transaction-runtime-object-id.workspace     = true


### PR DESCRIPTION
This PR centralizes all dependency declarations into the workspace root Cargo.toml.

Every crate across all 52 packages now uses dep.workspace = true instead of inline version specifiers or git URLs.

External crates, Kaspa git dependencies, and internal path references are each declared once under [workspace.dependencies], eliminating version drift and reducing future upgrades to a single-line change.
