### PR TITLE
Feat: Reorg filter for L1 bridge (high-pass denoising)

### DIFF
--- a/node/l1-bridge/src/config.rs
+++ b/node/l1-bridge/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::{ChainBlock, ConnectStrategy, NetworkId, NetworkType};
 
 /// Configuration for the L1 bridge.
@@ -16,6 +18,9 @@ pub struct L1BridgeConfig {
     pub root: Option<ChainBlock>,
     /// Last known tip, or `None` to start from the L1 pruning point.
     pub tip: Option<ChainBlock>,
+    /// Reorg filter halving period. Observed reorg depths accumulate into a threshold that halves
+    /// every period until it reaches zero. Set to `Duration::ZERO` to disable (default).
+    pub reorg_filter_period: Duration,
 }
 
 impl Default for L1BridgeConfig {
@@ -28,6 +33,7 @@ impl Default for L1BridgeConfig {
             connect_strategy: ConnectStrategy::Retry, // Reconnect automatically on disconnect.
             root: None,                               // Start from the L1 pruning point.
             tip: None,
+            reorg_filter_period: Duration::ZERO, // Disabled by default.
         }
     }
 }
@@ -72,6 +78,13 @@ impl L1BridgeConfig {
     /// Sets the last known tip to resume from.
     pub fn with_tip(mut self, block: Option<ChainBlock>) -> Self {
         self.tip = block;
+        self
+    }
+
+    /// Sets the reorg filter halving period. Observed reorg depths accumulate into a threshold that
+    /// halves every period, filtering smaller reorgs until the threshold decays to zero.
+    pub fn with_reorg_filter_period(mut self, period: Duration) -> Self {
+        self.reorg_filter_period = period;
         self
     }
 }

--- a/node/l1-bridge/src/config.rs
+++ b/node/l1-bridge/src/config.rs
@@ -20,7 +20,7 @@ pub struct L1BridgeConfig {
     pub tip: Option<ChainBlock>,
     /// Reorg filter halving period. Observed reorg depths accumulate into a threshold that halves
     /// every period until it reaches zero. Set to `Duration::ZERO` to disable (default).
-    pub reorg_filter_period: Duration,
+    pub reorg_filter_halving_period: Duration,
 }
 
 impl Default for L1BridgeConfig {
@@ -33,7 +33,7 @@ impl Default for L1BridgeConfig {
             connect_strategy: ConnectStrategy::Retry, // Reconnect automatically on disconnect.
             root: None,                               // Start from the L1 pruning point.
             tip: None,
-            reorg_filter_period: Duration::ZERO, // Disabled by default.
+            reorg_filter_halving_period: Duration::ZERO, // Disabled by default.
         }
     }
 }
@@ -83,8 +83,8 @@ impl L1BridgeConfig {
 
     /// Sets the reorg filter halving period. Observed reorg depths accumulate into a threshold that
     /// halves every period, filtering smaller reorgs until the threshold decays to zero.
-    pub fn with_reorg_filter_period(mut self, period: Duration) -> Self {
-        self.reorg_filter_period = period;
+    pub fn with_reorg_filter_halving_period(mut self, period: Duration) -> Self {
+        self.reorg_filter_halving_period = period;
         self
     }
 }

--- a/node/l1-bridge/src/event.rs
+++ b/node/l1-bridge/src/event.rs
@@ -20,7 +20,12 @@ pub enum L1Event {
         accepted_transactions: Vec<RpcOptionalTransaction>,
     },
     /// Blocks after this index have been removed due to a reorg.
-    Rollback(u64),
+    Rollback {
+        /// New tip index after the rollback.
+        index: u64,
+        /// Blue score difference between old and new tip.
+        blue_score_depth: u64,
+    },
     /// Blocks up to this block are finalized and can be pruned.
     Finalized(ChainBlock),
     /// The bridge encountered a fatal error and stopped.

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -23,7 +23,9 @@
 //!         Some(L1Event::ChainBlockAdded { index, .. }) => {
 //!             println!("block {index}");
 //!         }
-//!         Some(L1Event::Rollback(index)) => println!("rollback to {index}"),
+//!         Some(L1Event::Rollback { index, blue_score_depth }) => {
+//!             println!("rollback to {index} (depth: {blue_score_depth})");
+//!         }
 //!         Some(L1Event::Finalized(block)) => {
 //!             println!("finalized up to index {}", block.index());
 //!         }

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -55,6 +55,7 @@ mod chain_block;
 mod config;
 mod error;
 mod event;
+mod reorg_filter;
 mod virtual_chain;
 mod worker;
 

--- a/node/l1-bridge/src/reorg_filter.rs
+++ b/node/l1-bridge/src/reorg_filter.rs
@@ -1,0 +1,53 @@
+use std::time::{Duration, Instant};
+
+/// Filters reorgs using halving-based decay.
+///
+/// Observed reorg depths accumulate into a threshold that determines the `min_confirmation_count`
+/// passed to the L1 API. Every period, the threshold halves until it reaches zero. This creates
+/// stable oscillation around a level that filters most reorgs while allowing visibility when the
+/// network stabilizes.
+pub(crate) struct ReorgFilter {
+    /// Halving period, or zero to disable filtering.
+    period: Duration,
+    /// Current threshold level (halves each period).
+    threshold: u64,
+    /// When the next halving occurs.
+    next_halving: Option<Instant>,
+}
+
+impl ReorgFilter {
+    /// Creates a new filter with the given halving period. Pass `Duration::ZERO` to disable.
+    pub(crate) fn new(period: Duration) -> Self {
+        Self { period, threshold: 0, next_halving: None }
+    }
+
+    /// Returns the current threshold after applying any pending halvings.
+    ///
+    /// Returns `None` if the filter is disabled (zero period) or the threshold has decayed to zero.
+    pub(crate) fn threshold(&mut self) -> Option<u64> {
+        if self.period.is_zero() {
+            return None;
+        }
+
+        // Apply halvings for each expired period.
+        if let Some(mut expiry) = self.next_halving {
+            while Instant::now() >= expiry && self.threshold > 0 {
+                self.threshold /= 2;
+                expiry += self.period;
+            }
+
+            self.next_halving = if self.threshold == 0 { None } else { Some(expiry) };
+        }
+
+        if self.threshold == 0 { None } else { Some(self.threshold) }
+    }
+
+    /// Records a reorg of the given depth, adding it to the threshold and resetting the halving
+    /// timer.
+    pub(crate) fn record(&mut self, depth: u64) {
+        if !self.period.is_zero() && depth != 0 {
+            self.threshold += depth;
+            self.next_halving = Some(Instant::now() + self.period);
+        }
+    }
+}

--- a/node/l1-bridge/src/virtual_chain.rs
+++ b/node/l1-bridge/src/virtual_chain.rs
@@ -45,14 +45,13 @@ impl VirtualChain {
             return Err(Error::RollbackPastRoot { target_index, root_index: self.root.index() });
         }
 
+        // Calculate reorg_depth and walk backwards, unlinking each block from its predecessor.
         let old_blue_score = self.tip.blue_score();
-
-        // Walk backwards, unlinking each block from its predecessor.
         for _ in 0..num_blocks {
             self.tip = self.tip.rollback_tip();
         }
-
         let blue_score_depth = old_blue_score.saturating_sub(self.tip.blue_score());
+
         Ok((self.tip.index(), blue_score_depth))
     }
 

--- a/node/l1-bridge/src/worker.rs
+++ b/node/l1-bridge/src/worker.rs
@@ -256,18 +256,19 @@ impl BridgeWorker {
             target.index(),
         );
 
-        // Fetch with default verbosity (server defaults to Full) so we get headers with blue
-        // scores needed for the chain blocks.
-        let response =
-            self.client.get_virtual_chain_from_block_v2(start.hash(), None, None).await?;
+        // Fetch with Low verbosity — sufficient for hash and blue_score needed for chain blocks.
+        let response = self
+            .client
+            .get_virtual_chain_from_block_v2(start.hash(), Some(RpcDataVerbosityLevel::Low), None)
+            .await?;
 
         // Walk the chain block accepted transactions to get both hash and blue_score.
         let target_hash = target.hash();
         let mut found = false;
 
-        for acd in response.chain_block_accepted_transactions.iter() {
-            let hash = acd.chain_block_header.hash.unwrap_or_default();
-            let blue_score = acd.chain_block_header.blue_score.unwrap_or(0);
+        for chain_block in response.chain_block_accepted_transactions.iter() {
+            let hash = chain_block.chain_block_header.hash.unwrap_or_default();
+            let blue_score = chain_block.chain_block_header.blue_score.unwrap_or(0);
             self.virtual_chain.advance_tip(hash, blue_score);
             if hash == target_hash {
                 found = true;

--- a/node/l1-bridge/src/worker.rs
+++ b/node/l1-bridge/src/worker.rs
@@ -110,7 +110,7 @@ impl BridgeWorker {
             rpc_ctl_channel,
             fatal: false,
             backfill_target,
-            reorg_filter: ReorgFilter::new(config.reorg_filter_period),
+            reorg_filter: ReorgFilter::new(config.reorg_filter_halving_period),
         })
     }
 

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -93,7 +93,7 @@ async fn test_bridge_syncs_from_specific_block() {
         .with_url(node.wrpc_borsh_url())
         .with_network_type(NetworkType::Simnet)
         .with_connect_strategy(ConnectStrategy::Fallback)
-        .with_tip(Some(ChainBlock::new(start_from, 3)));
+        .with_tip(Some(ChainBlock::new(start_from, 3, 0)));
 
     let bridge = L1Bridge::new(config);
 
@@ -152,7 +152,7 @@ async fn test_bridge_catches_up_after_reconnection() {
 
     // Save the last processed position as a checkpoint.
     let (last_index, last_header, _) = &blocks[2];
-    let checkpoint = ChainBlock::new(last_header.hash.unwrap(), *last_index);
+    let checkpoint = ChainBlock::new(last_header.hash.unwrap(), *last_index, 0);
     assert_eq!(*last_index, 3);
 
     // Phase 2: Shutdown the bridge, mine blocks while it's down.
@@ -229,7 +229,7 @@ async fn test_bridge_receives_reorg_events() {
 
     // Depending on Kaspa's internal timing, we may see a discrete Rollback
     // event or blocks may propagate incrementally without one.
-    let rollback_pos = events.iter().position(|e| matches!(e, L1Event::Rollback(_)));
+    let rollback_pos = events.iter().position(|e| matches!(e, L1Event::Rollback { .. }));
 
     if let Some(pos) = rollback_pos {
         // Reorg detected — verify blocks after rollback are from the main chain.

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -278,6 +278,152 @@ async fn test_bridge_receives_reorg_events() {
     node1.shutdown().await;
 }
 
+/// Verifies that the reorg filter causes a bridge to lag behind the chain tip after a reorg.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_reorg_filter_causes_lag() {
+    const NODE1_BLOCKS: usize = 5;
+    const NODE2_BLOCKS: usize = 20;
+
+    // Use a very long filter period so no halving occurs during the test.
+    let filter_period = Duration::from_secs(3600);
+
+    // Create two isolated nodes.
+    let node1 = L1Node::new().await;
+    let node2 = L1Node::new().await;
+
+    // Create two bridges to node1: one with filter, one without.
+    let bridge_filtered = L1Bridge::new(
+        L1BridgeConfig::default()
+            .with_url(node1.wrpc_borsh_url())
+            .with_network_type(NetworkType::Simnet)
+            .with_connect_strategy(ConnectStrategy::Fallback)
+            .with_reorg_filter_period(filter_period),
+    );
+    let bridge_unfiltered = L1Bridge::new(
+        L1BridgeConfig::default()
+            .with_url(node1.wrpc_borsh_url())
+            .with_network_type(NetworkType::Simnet)
+            .with_connect_strategy(ConnectStrategy::Fallback),
+    );
+
+    // Wait for both bridges to connect.
+    tokio::join!(
+        bridge_filtered.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)),
+        bridge_unfiltered.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)),
+    );
+
+    // Mine chains on both nodes in isolation. Wait for node1's chain to be fully synced.
+    let hashes1 = node1.mine_blocks(NODE1_BLOCKS).await;
+    let last_hash1 = *hashes1.last().unwrap();
+
+    tokio::join!(
+        bridge_filtered.wait_for(TIMEOUT, |e| {
+            matches!(e, L1Event::ChainBlockAdded { header, .. } if header.hash == Some(last_hash1))
+        }),
+        bridge_unfiltered.wait_for(TIMEOUT, |e| {
+            matches!(e, L1Event::ChainBlockAdded { header, .. } if header.hash == Some(last_hash1))
+        }),
+    );
+
+    // Mine the longer chain on node2 and wait for its last block to be accepted.
+    let hashes2 = node2.mine_blocks(NODE2_BLOCKS).await;
+    let last_hash2 = *hashes2.last().unwrap();
+
+    // Create a temporary bridge to node2 to ensure all blocks are mined before connecting.
+    let bridge_node2 = L1Bridge::new(
+        L1BridgeConfig::default()
+            .with_url(node2.wrpc_borsh_url())
+            .with_network_type(NetworkType::Simnet)
+            .with_connect_strategy(ConnectStrategy::Fallback),
+    );
+    bridge_node2
+        .wait_for(TIMEOUT, |e| {
+            matches!(e, L1Event::ChainBlockAdded { header, .. } if header.hash == Some(last_hash2))
+        })
+        .await;
+    bridge_node2.shutdown();
+
+    // Connect nodes - node1 reorgs to node2's longer chain.
+    node1.connect_to(&node2).await;
+
+    // Wait for the unfiltered bridge to see the last block from node2.
+    let events_unfiltered = bridge_unfiltered
+        .wait_for(TIMEOUT, |e| {
+            matches!(e, L1Event::ChainBlockAdded { header, .. } if header.hash == Some(last_hash2))
+        })
+        .await;
+
+    // Verify we saw the rollback with the expected depth.
+    let rollback_depth = events_unfiltered
+        .iter()
+        .find_map(|e| match e {
+            L1Event::Rollback { blue_score_depth, .. } => Some(*blue_score_depth),
+            _ => None,
+        })
+        .expect("unfiltered bridge should see rollback");
+
+    assert_eq!(
+        rollback_depth, NODE1_BLOCKS as u64,
+        "rollback depth should equal {} (node1's original chain)",
+        NODE1_BLOCKS
+    );
+
+    // The unfiltered bridge's max index should be NODE2_BLOCKS.
+    let max_index_unfiltered = events_unfiltered
+        .iter()
+        .filter_map(|e| match e {
+            L1Event::ChainBlockAdded { index, .. } => Some(*index),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0);
+
+    assert_eq!(
+        max_index_unfiltered, NODE2_BLOCKS as u64,
+        "unfiltered bridge should reach index {}",
+        NODE2_BLOCKS
+    );
+
+    // Give the filtered bridge time to process, then check its max index.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let events_filtered = bridge_filtered.drain();
+
+    let rollback_filtered = events_filtered
+        .iter()
+        .find_map(|e| match e {
+            L1Event::Rollback { blue_score_depth, .. } => Some(*blue_score_depth),
+            _ => None,
+        })
+        .expect("filtered bridge should see rollback");
+
+    assert_eq!(rollback_filtered, NODE1_BLOCKS as u64);
+
+    let max_index_filtered = events_filtered
+        .iter()
+        .filter_map(|e| match e {
+            L1Event::ChainBlockAdded { index, .. } => Some(*index),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0);
+
+    // The filtered bridge should lag behind. The API filters blocks where distance > threshold,
+    // so with threshold=5 and tip=20, we see blocks 1-14 (distance 6+). To be protected from
+    // reorgs of depth N, we must not show blocks at distance ≤ N, hence the lag is threshold+1.
+    let expected_lag = NODE1_BLOCKS + 1;
+    let expected_filtered_max = (NODE2_BLOCKS - expected_lag) as u64;
+    assert_eq!(
+        max_index_filtered, expected_filtered_max,
+        "filtered bridge should lag by {} blocks (max index {} vs {})",
+        expected_lag, max_index_filtered, max_index_unfiltered
+    );
+
+    bridge_filtered.shutdown();
+    bridge_unfiltered.shutdown();
+    node1.shutdown().await;
+    node2.shutdown().await;
+}
+
 /// Starts an L1 node and a connected bridge, waiting for the `Connected` event.
 async fn setup_node_with_bridge(
     strategy: ConnectStrategy,

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -294,7 +294,7 @@ async fn test_reorg_filter_causes_lag() {
             .with_url(node1.wrpc_borsh_url())
             .with_network_type(NetworkType::Simnet)
             .with_connect_strategy(ConnectStrategy::Fallback)
-            .with_reorg_filter_period(Duration::from_secs(3600)),
+            .with_reorg_filter_halving_period(Duration::from_secs(3600)),
     );
     let unfiltered = L1Bridge::new(
         L1BridgeConfig::default()


### PR DESCRIPTION
This PR introduces a reorg filter for the L1 bridge that acts as a high-pass filter for chain reorganizations, reducing noise from frequent shallow reorgs while preserving visibility of significant chain changes.

**Problem:**

The L1 bridge exposes every reorg to consumers, including frequent shallow reorgs that are normal network behavior. This creates unnecessary churn for downstream systems that don't need to react to every minor chain adjustment.
                                                                                                                                                                                                                            
**Solution:**

A new ReorgFilter that dynamically adjusts the min_confirmation_count parameter passed to the L1 API's get_virtual_chain_from_block_v2 call. Blocks must exceed this confirmation threshold before becoming visible to consumers.

**How it works:**

  - When a reorg is observed, its depth (in blue score) is added to the filter's threshold
  - The threshold halves every reorg_filter_period, creating logarithmic decay back to zero
  - This creates stable oscillation around the network's typical reorg depth — frequent reorgs of similar depth push the threshold up, while periods of stability allow it to decay
  - The mechanism is self-tuning: no baseline configuration needed, the filter naturally adapts to network conditions

**Configuration:**

  - reorg_filter_halving_period: Duration — the halving period (e.g., Duration::from_secs(6 * 3600) for 6-hour halving)
  - Set to Duration::ZERO to disable (default)