### PR TITLE
Feat: Node framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5470,6 +5470,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vprogs-node-framework"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "log",
+ "thiserror 2.0.18",
+ "tokio",
+ "vprogs-core-atomics",
+ "vprogs-core-types",
+ "vprogs-node-l1-bridge",
+ "vprogs-scheduling-scheduler",
+ "vprogs-state-space",
+ "vprogs-storage-manager",
+ "vprogs-storage-types",
+]
+
+[[package]]
 name = "vprogs-node-l1-bridge"
 version = "0.1.0"
 dependencies = [
@@ -5518,6 +5535,8 @@ dependencies = [
 name = "vprogs-node-vm"
 version = "0.1.0"
 dependencies = [
+ "vprogs-node-framework",
+ "vprogs-node-l1-bridge",
  "vprogs-scheduling-scheduler",
  "vprogs-state-space",
  "vprogs-storage-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,15 +100,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
 dependencies = [
  "rustversion",
 ]
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.14.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -200,7 +200,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.4",
+ "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -262,7 +262,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -416,7 +416,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -427,9 +427,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2b_simd"
@@ -493,7 +493,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -520,9 +520,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2-sys"
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -601,9 +601,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -663,21 +663,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -817,12 +817,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.2"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.30.1",
  "windows-sys 0.61.2",
 ]
 
@@ -857,7 +857,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -904,9 +904,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -930,7 +930,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -1018,11 +1018,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "block2",
  "libc",
  "objc2",
@@ -1036,7 +1036,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1104,7 +1104,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1180,9 +1180,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "fixedbitset"
@@ -1192,9 +1192,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1207,12 +1207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1238,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1248,15 +1242,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1265,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1284,32 +1278,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1319,6 +1313,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -1360,19 +1355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "getset"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,7 +1363,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1453,15 +1435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -1662,7 +1635,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -1680,13 +1653,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1705,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1807,12 +1781,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1968,15 +1936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2004,8 +1963,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "js-sys",
@@ -2019,8 +1978,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2041,16 +2000,16 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-bip32"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "bs58",
@@ -2076,8 +2035,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2094,8 +2053,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2135,8 +2094,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -2164,12 +2123,12 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "arc-swap",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "borsh",
  "cfg-if",
  "faster-hex",
@@ -2201,8 +2160,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
@@ -2221,8 +2180,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "cfg-if",
  "faster-hex",
@@ -2246,8 +2205,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "duration-string",
  "futures",
@@ -2266,8 +2225,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2286,8 +2245,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2309,8 +2268,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2342,8 +2301,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2373,8 +2332,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2404,13 +2363,13 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "triggered",
- "uuid 1.21.0",
+ "uuid 1.20.0",
 ]
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2428,8 +2387,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2448,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2474,8 +2433,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "faster-hex",
@@ -2494,16 +2453,16 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-mining"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -2528,8 +2487,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 1.0.69",
@@ -2537,8 +2496,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -2548,8 +2507,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2580,8 +2539,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2608,13 +2567,13 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "uuid 1.21.0",
+ "uuid 1.20.0",
 ]
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2639,13 +2598,13 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
- "uuid 1.21.0",
+ "uuid 1.20.0",
 ]
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -2662,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2675,8 +2634,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "js-sys",
  "kaspa-consensus-client",
@@ -2691,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2725,7 +2684,7 @@ dependencies = [
  "serde_nested_with",
  "smallvec",
  "thiserror 1.0.69",
- "uuid 1.21.0",
+ "uuid 1.20.0",
  "wasm-bindgen",
  "workflow-core",
  "workflow-serializer",
@@ -2734,8 +2693,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2747,8 +2706,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -2778,14 +2737,14 @@ dependencies = [
 
 [[package]]
 name = "kaspa-testing-integration"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
  "bincode",
  "chrono",
- "clap 4.5.60",
+ "clap 4.5.54",
  "crossbeam-channel",
  "faster-hex",
  "flate2",
@@ -2836,8 +2795,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2867,8 +2826,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "secp256k1",
  "thiserror 1.0.69",
@@ -2876,8 +2835,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2900,14 +2859,14 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "triggered",
- "uuid 1.21.0",
+ "uuid 1.20.0",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2923,8 +2882,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "futures",
  "kaspa-consensus-core",
@@ -2943,8 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "faster-hex",
  "hexplay",
@@ -2955,8 +2914,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-client"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2992,8 +2951,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3021,12 +2980,12 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
+version = "1.1.0-rc.2"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#d44e31aee830b012bd65e7fe43031f9686b7e099"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
- "clap 4.5.60",
+ "clap 4.5.54",
  "dirs",
  "futures-util",
  "itertools 0.13.0",
@@ -3072,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -3101,16 +3060,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libloading"
@@ -3140,10 +3093,11 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -3165,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3202,9 +3156,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3214,9 +3168,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.10"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
+checksum = "92488bc8a0f99ee9f23577bdd06526d49657df8bd70504c61f812337cdad01ab"
 dependencies = [
  "libc",
  "neli",
@@ -3353,9 +3307,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -3422,11 +3376,11 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "neli"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "byteorder",
  "derive_builder",
  "getset",
@@ -3446,7 +3400,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3455,7 +3409,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3464,11 +3418,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3486,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
  "winapi",
 ]
@@ -3594,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -3690,7 +3644,7 @@ checksum = "70d80829147ec6f1b27109c7daaea62fc3a21a0348cdddf22b4093f0c35ab25a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3733,29 +3687,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3765,9 +3719,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -3790,15 +3744,15 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.1.4",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "potential_utf"
@@ -3831,7 +3785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3885,14 +3839,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -3914,7 +3868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3923,7 +3877,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -3934,10 +3888,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4006,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -4114,7 +4068,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4145,14 +4099,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4162,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4173,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
@@ -4215,7 +4169,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -4287,7 +4241,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4296,22 +4250,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -4360,9 +4314,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "schemars"
@@ -4378,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4481,7 +4435,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4506,7 +4460,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro-error2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4532,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64",
  "chrono",
@@ -4542,7 +4496,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.0",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4551,14 +4505,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4652,9 +4606,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4728,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4754,7 +4708,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4773,11 +4727,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4800,14 +4754,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.4",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -4855,7 +4809,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4866,7 +4820,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4891,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -4914,9 +4868,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4971,7 +4925,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5082,9 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -5140,7 +5094,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5184,7 +5138,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -5200,7 +5154,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -5243,7 +5197,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5304,9 +5258,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5394,11 +5348,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "js-sys",
  "rand 0.9.2",
  "serde_core",
@@ -5458,7 +5412,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5529,6 +5483,7 @@ dependencies = [
  "kaspad",
  "secp256k1",
  "serde_json",
+ "tap",
  "tempfile",
  "tokio",
  "vprogs-core-types",
@@ -5890,27 +5845,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5923,9 +5869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5937,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5947,65 +5893,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6027,14 +5939,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6125,7 +6037,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6136,7 +6048,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6147,7 +6059,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6158,7 +6070,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6447,91 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "workflow-core"
@@ -6857,28 +6687,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6898,7 +6728,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -6938,14 +6768,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
 
 [[package]]
 name = "zstd-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -200,7 +200,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -262,7 +262,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -493,7 +493,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -601,9 +601,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -670,7 +670,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -817,12 +817,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.30.1",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -857,7 +857,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -904,9 +904,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -930,7 +930,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
@@ -1036,7 +1036,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1104,7 +1104,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "kaspa-addresses"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "borsh",
  "js-sys",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "kaspa-addressmanager"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "borsh",
  "igd-next",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "kaspa-alloc"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "mimalloc",
 ]
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "kaspa-bip32"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "borsh",
  "bs58",
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "kaspa-connectionmanager"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-client"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2202,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-notify"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-wasm"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "cfg-if",
  "faster-hex",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensusmanager"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "duration-string",
  "futures",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "kaspa-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "kaspa-database"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "kaspa-grpc-client"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "kaspa-grpc-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "kaspa-grpc-server"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "kaspa-hashes"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "kaspa-index-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "kaspa-index-processor"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "kaspa-math"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "borsh",
  "faster-hex",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "kaspa-merkle"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "kaspa-hashes",
 ]
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "kaspa-mining"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -2529,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "kaspa-mining-errors"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 1.0.69",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "kaspa-muhash"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "kaspa-notify"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "kaspa-p2p-flows"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "kaspa-p2p-lib"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "kaspa-p2p-mining"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "kaspa-perf-monitor"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "kaspa-core",
  "log",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "kaspa-pow"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "js-sys",
  "kaspa-consensus-client",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -2735,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-macros"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "kaspa-rpc-service"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -2779,13 +2779,13 @@ dependencies = [
 [[package]]
 name = "kaspa-testing-integration"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
  "bincode",
  "chrono",
- "clap 4.5.59",
+ "clap 4.5.60",
  "crossbeam-channel",
  "faster-hex",
  "flate2",
@@ -2837,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -2868,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript-errors"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "secp256k1",
  "thiserror 1.0.69",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "kaspa-utils"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "kaspa-utils-tower"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "kaspa-utxoindex"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "futures",
  "kaspa-consensus-core",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wasm-core"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "faster-hex",
  "hexplay",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wrpc-client"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2993,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wrpc-server"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3022,11 +3022,11 @@ dependencies = [
 [[package]]
 name = "kaspad"
 version = "1.1.0-rc.3"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#60e4975bd2a390268643e57036c8e62da1b026c0"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=master#b6c7dece7ecf5df4b12c146622c11a61b474a755"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
- "clap 4.5.59",
+ "clap 4.5.60",
  "dirs",
  "futures-util",
  "itertools 0.13.0",
@@ -3140,11 +3140,10 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
 ]
 
@@ -3166,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3203,9 +3202,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3447,7 +3446,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3465,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -3595,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -3691,7 +3690,7 @@ checksum = "70d80829147ec6f1b27109c7daaea62fc3a21a0348cdddf22b4093f0c35ab25a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3734,29 +3733,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3766,9 +3765,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -3791,7 +3790,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3832,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3886,7 +3885,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3924,7 +3923,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.116",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3938,7 +3937,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4146,7 +4145,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4174,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -4297,22 +4296,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -4482,7 +4481,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4507,7 +4506,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro-error2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4533,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
@@ -4552,14 +4551,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4729,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4755,7 +4754,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4801,14 +4800,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4856,7 +4855,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4867,7 +4866,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4972,7 +4971,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5141,7 +5140,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5244,7 +5243,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5459,7 +5458,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5475,14 +5474,18 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "log",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "vprogs-core-atomics",
  "vprogs-core-types",
  "vprogs-node-l1-bridge",
+ "vprogs-node-test-suite",
  "vprogs-scheduling-scheduler",
+ "vprogs-state-metadata",
  "vprogs-state-space",
  "vprogs-storage-manager",
+ "vprogs-storage-rocksdb-store",
  "vprogs-storage-types",
 ]
 
@@ -5525,10 +5528,18 @@ dependencies = [
  "kaspad",
  "secp256k1",
  "serde_json",
- "tap",
  "tempfile",
  "tokio",
+ "vprogs-core-types",
+ "vprogs-node-framework",
  "vprogs-node-l1-bridge",
+ "vprogs-scheduling-scheduler",
+ "vprogs-scheduling-test-suite",
+ "vprogs-state-metadata",
+ "vprogs-state-space",
+ "vprogs-state-version",
+ "vprogs-storage-rocksdb-store",
+ "vprogs-storage-types",
 ]
 
 [[package]]
@@ -5896,9 +5907,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5911,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5925,9 +5936,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5935,22 +5946,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -5991,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6113,7 +6124,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6124,7 +6135,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6135,7 +6146,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6146,7 +6157,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6463,7 +6474,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6479,7 +6490,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6845,28 +6856,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6886,7 +6897,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6926,7 +6937,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "vprogs-core-atomics",
+ "vprogs-core-macros",
  "vprogs-core-types",
  "vprogs-node-l1-bridge",
  "vprogs-node-test-suite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ resolver = "3"
   vprogs-core-atomics                             = { path = "core/atomics" }
   vprogs-core-macros                              = { path = "core/macros" }
   vprogs-core-types                               = { path = "core/types" }
+  vprogs-node-framework                           = { path = "node/framework" }
   vprogs-node-l1-bridge                           = { path = "node/l1-bridge" }
   vprogs-node-test-suite                          = { path = "node/test-suite" }
   vprogs-node-vm                                  = { path = "node/vm" }

--- a/node/framework/Cargo.toml
+++ b/node/framework/Cargo.toml
@@ -9,6 +9,7 @@ log.workspace                         = true
 thiserror.workspace                   = true
 tokio.workspace                       = true
 vprogs-core-atomics.workspace         = true
+vprogs-core-macros.workspace          = true
 vprogs-core-types.workspace           = true
 vprogs-node-l1-bridge.workspace       = true
 vprogs-scheduling-scheduler.workspace = true

--- a/node/framework/Cargo.toml
+++ b/node/framework/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition.workspace = true
+name              = "vprogs-node-framework"
+version.workspace = true
+
+[dependencies]
+arc-swap.workspace                    = true
+log.workspace                         = true
+thiserror.workspace                   = true
+tokio.workspace                       = true
+vprogs-core-atomics.workspace         = true
+vprogs-core-types.workspace           = true
+vprogs-node-l1-bridge.workspace       = true
+vprogs-scheduling-scheduler.workspace = true
+vprogs-state-space.workspace          = true
+vprogs-storage-manager.workspace      = true
+vprogs-storage-types.workspace        = true

--- a/node/framework/Cargo.toml
+++ b/node/framework/Cargo.toml
@@ -15,3 +15,10 @@ vprogs-scheduling-scheduler.workspace = true
 vprogs-state-space.workspace          = true
 vprogs-storage-manager.workspace      = true
 vprogs-storage-types.workspace        = true
+
+[dev-dependencies]
+tempfile.workspace                     = true
+tokio                                  = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+vprogs-node-test-suite.workspace       = true
+vprogs-state-metadata.workspace        = true
+vprogs-storage-rocksdb-store.workspace = true

--- a/node/framework/src/api.rs
+++ b/node/framework/src/api.rs
@@ -30,9 +30,9 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
         self.with_scheduler(|s| s.batch_execution().last_processed().clone()).await
     }
 
-    /// Returns the last pruned checkpoint.
-    pub async fn last_pruned(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
-        self.with_scheduler(|s| s.pruning().last_pruned()).await
+    /// Returns the root checkpoint (oldest surviving batch).
+    pub async fn root(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
+        self.with_scheduler(|s| s.pruning().root()).await
     }
 
     /// Returns the current pruning threshold.

--- a/node/framework/src/api.rs
+++ b/node/framework/src/api.rs
@@ -1,7 +1,6 @@
 use tokio::sync::{mpsc::Sender, oneshot};
-use vprogs_core_types::Checkpoint;
-use vprogs_node_l1_bridge::ChainBlockMetadata;
-use vprogs_scheduling_scheduler::Scheduler;
+use vprogs_core_macros::smart_pointer;
+use vprogs_scheduling_scheduler::{Scheduler, SchedulerState};
 use vprogs_state_space::StateSpace;
 use vprogs_storage_types::Store;
 
@@ -12,37 +11,23 @@ use crate::{
 
 /// Cloneable handle for querying the scheduler from outside the worker thread.
 ///
-/// Sends closures over a channel to the worker thread, where they execute against the
-/// [`Scheduler`]. Each closure captures a [`oneshot::Sender`] for the response. The worker
-/// executes the closure and the caller awaits the oneshot.
-pub struct NodeApi<S: Store<StateSpace = StateSpace>, V: NodeVm>(
-    pub(crate) Sender<ApiRequest<S, V>>,
-);
+/// Derefs to [`SchedulerState`], exposing lock-free reads for `root`, `last_committed`,
+/// `last_processed`, and `storage` without going through the worker channel.
+///
+/// For operations that need `&mut Scheduler` (e.g. pruning), use
+/// [`with_scheduler`](Self::with_scheduler).
+#[smart_pointer(deref(state))]
+pub struct NodeApi<S: Store<StateSpace = StateSpace>, V: NodeVm> {
+    /// Shared scheduler state for lock-free reads (deref target).
+    state: SchedulerState<S, V>,
+    /// Channel for sending closures to the worker thread for `&mut Scheduler` access.
+    api_requests: Sender<ApiRequest<S, V>>,
+}
 
 impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
-    /// Returns the last committed checkpoint.
-    pub async fn last_committed(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
-        self.with_scheduler(|s| s.batch_execution().last_committed().clone()).await
-    }
-
-    /// Returns the last processed checkpoint.
-    pub async fn last_processed(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
-        self.with_scheduler(|s| s.batch_execution().last_processed().clone()).await
-    }
-
-    /// Returns the root checkpoint (oldest surviving batch).
-    pub async fn root(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
-        self.with_scheduler(|s| s.pruning().root()).await
-    }
-
-    /// Returns the current pruning threshold.
-    pub async fn pruning_threshold(&self) -> NodeResult<u64> {
-        self.with_scheduler(|s| s.pruning().threshold()).await
-    }
-
-    /// Returns the number of resources currently cached in the scheduler.
-    pub async fn cached_resource_count(&self) -> NodeResult<usize> {
-        self.with_scheduler(|s| s.cached_resource_count()).await
+    /// Creates a new API handle with shared state and a channel to the worker thread.
+    pub(crate) fn new(state: SchedulerState<S, V>, sender: Sender<ApiRequest<S, V>>) -> Self {
+        Self(std::sync::Arc::new(NodeApiData { state, api_requests: sender }))
     }
 
     /// Executes a closure against the scheduler on the worker thread and returns the result.
@@ -55,7 +40,7 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
 
         // Wrap the user's closure to capture the oneshot sender. The worker will execute
         // this against &mut Scheduler and send the return value back.
-        self.0
+        self.api_requests
             .send(Box::new(move |scheduler| {
                 // Ignore send errors - the caller may have timed out or dropped the future.
                 let _ = tx.send(f(scheduler));
@@ -65,13 +50,6 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
 
         // Await the response from the worker thread.
         rx.await.map_err(|_| NodeError::RequestDropped)
-    }
-}
-
-// Manual Clone impl to avoid unnecessary bounds on S and V.
-impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Clone for NodeApi<S, V> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
     }
 }
 

--- a/node/framework/src/api.rs
+++ b/node/framework/src/api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tokio::sync::{mpsc::Sender, oneshot};
 use vprogs_core_macros::smart_pointer;
 use vprogs_scheduling_scheduler::{Scheduler, SchedulerState};
@@ -9,13 +11,11 @@ use crate::{
     error::{NodeError, NodeResult},
 };
 
-/// Cloneable handle for querying the scheduler from outside the worker thread.
+/// Cloneable handle for interacting with the node.
 ///
 /// Derefs to [`SchedulerState`], exposing lock-free reads for `root`, `last_committed`,
-/// `last_processed`, and `storage` without going through the worker channel.
-///
-/// For operations that need `&mut Scheduler` (e.g. pruning), use
-/// [`with_scheduler`](Self::with_scheduler).
+/// `last_processed`, and `storage`. For operations that need `&mut Scheduler` (e.g. pruning),
+/// use [`with_scheduler`](Self::with_scheduler).
 #[smart_pointer(deref(state))]
 pub struct NodeApi<S: Store<StateSpace = StateSpace>, V: NodeVm> {
     /// Shared scheduler state for lock-free reads (deref target).
@@ -27,7 +27,7 @@ pub struct NodeApi<S: Store<StateSpace = StateSpace>, V: NodeVm> {
 impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
     /// Creates a new API handle with shared state and a channel to the worker thread.
     pub(crate) fn new(state: SchedulerState<S, V>, sender: Sender<ApiRequest<S, V>>) -> Self {
-        Self(std::sync::Arc::new(NodeApiData { state, api_requests: sender }))
+        Self(Arc::new(NodeApiData { state, api_requests: sender }))
     }
 
     /// Executes a closure against the scheduler on the worker thread and returns the result.

--- a/node/framework/src/api.rs
+++ b/node/framework/src/api.rs
@@ -1,0 +1,79 @@
+use tokio::sync::{mpsc::Sender, oneshot};
+use vprogs_core_types::Checkpoint;
+use vprogs_node_l1_bridge::ChainBlockMetadata;
+use vprogs_scheduling_scheduler::Scheduler;
+use vprogs_state_space::StateSpace;
+use vprogs_storage_types::Store;
+
+use crate::{
+    NodeVm,
+    error::{NodeError, NodeResult},
+};
+
+/// Cloneable handle for querying the scheduler from outside the worker thread.
+///
+/// Sends closures over a channel to the worker thread, where they execute against the
+/// [`Scheduler`]. Each closure captures a [`oneshot::Sender`] for the response. The worker
+/// executes the closure and the caller awaits the oneshot.
+pub struct NodeApi<S: Store<StateSpace = StateSpace>, V: NodeVm>(
+    pub(crate) Sender<ApiRequest<S, V>>,
+);
+
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeApi<S, V> {
+    /// Returns the last committed checkpoint.
+    pub async fn last_committed(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
+        self.with_scheduler(|s| s.batch_execution().last_committed().clone()).await
+    }
+
+    /// Returns the last processed checkpoint.
+    pub async fn last_processed(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
+        self.with_scheduler(|s| s.batch_execution().last_processed().clone()).await
+    }
+
+    /// Returns the last pruned checkpoint.
+    pub async fn last_pruned(&self) -> NodeResult<Checkpoint<ChainBlockMetadata>> {
+        self.with_scheduler(|s| s.pruning().last_pruned()).await
+    }
+
+    /// Returns the current pruning threshold.
+    pub async fn pruning_threshold(&self) -> NodeResult<u64> {
+        self.with_scheduler(|s| s.pruning().threshold()).await
+    }
+
+    /// Returns the number of resources currently cached in the scheduler.
+    pub async fn cached_resource_count(&self) -> NodeResult<usize> {
+        self.with_scheduler(|s| s.cached_resource_count()).await
+    }
+
+    /// Executes a closure against the scheduler on the worker thread and returns the result.
+    pub async fn with_scheduler<R: Send + 'static>(
+        &self,
+        f: impl FnOnce(&mut Scheduler<S, V>) -> R + Send + 'static,
+    ) -> NodeResult<R> {
+        // Create a oneshot pair - the closure will send the result back through `tx`.
+        let (tx, rx) = oneshot::channel();
+
+        // Wrap the user's closure to capture the oneshot sender. The worker will execute
+        // this against &mut Scheduler and send the return value back.
+        self.0
+            .send(Box::new(move |scheduler| {
+                // Ignore send errors - the caller may have timed out or dropped the future.
+                let _ = tx.send(f(scheduler));
+            }))
+            .await
+            .map_err(|_| NodeError::WorkerStopped)?;
+
+        // Await the response from the worker thread.
+        rx.await.map_err(|_| NodeError::RequestDropped)
+    }
+}
+
+// Manual Clone impl to avoid unnecessary bounds on S and V.
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Clone for NodeApi<S, V> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// A boxed closure sent over the API channel and executed against the scheduler by the worker.
+pub(crate) type ApiRequest<S, V> = Box<dyn FnOnce(&mut Scheduler<S, V>) + Send>;

--- a/node/framework/src/batch.rs
+++ b/node/framework/src/batch.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+use vprogs_core_atomics::AtomicAsyncLatch;
+
+use crate::NodeVm;
+
+/// One-shot container for pre-processing results.
+///
+/// A `Batch` is created when a chain block arrives and handed to an execution worker for
+/// pre-processing. The worker fills in the resulting transactions and metadata via
+/// [`set`](Self::set) and opens the latch, signaling the event loop that this batch is prepared.
+///
+/// Fully lock-free: results are published through an [`ArcSwapOption`] and coordination goes
+/// through the [`AtomicAsyncLatch`].
+pub(crate) struct Batch<V: NodeVm> {
+    index: u64,
+    result: ArcSwapOption<(Vec<V::Transaction>, V::BatchMetadata)>,
+    prepared: AtomicAsyncLatch,
+}
+
+impl<V: NodeVm> Batch<V> {
+    /// Creates a new empty batch for the given block index.
+    pub(crate) fn new(index: u64) -> Arc<Self> {
+        Arc::new(Self { index, result: ArcSwapOption::empty(), prepared: AtomicAsyncLatch::new() })
+    }
+
+    /// Returns the block index this batch corresponds to.
+    pub(crate) fn index(&self) -> u64 {
+        self.index
+    }
+
+    /// Returns `true` if pre-processing has completed.
+    pub(crate) fn is_prepared(&self) -> bool {
+        self.prepared.is_open()
+    }
+
+    /// Asynchronously waits until pre-processing completes.
+    pub(crate) async fn wait_until_prepared(&self) {
+        self.prepared.wait().await;
+    }
+
+    /// Stores the pre-processed transactions and metadata, marking the batch as prepared.
+    ///
+    /// Called by the execution worker after [`NodeVm::pre_process_block`] returns.
+    pub(crate) fn set(&self, txs: Vec<V::Transaction>, metadata: V::BatchMetadata) {
+        self.result.store(Some(Arc::new((txs, metadata))));
+        self.prepared.open();
+    }
+
+    /// Takes the pre-processed transactions and metadata out of the batch.
+    ///
+    /// Must only be called after [`wait_until_prepared`](Self::wait_until_prepared) or
+    /// [`is_prepared`](Self::is_prepared) returns `true`. Panics if the results have already been
+    /// taken.
+    pub(crate) fn take(&self) -> (Vec<V::Transaction>, V::BatchMetadata) {
+        let arc = self.result.swap(None).expect("results already taken");
+        Arc::into_inner(arc).expect("outstanding references to results")
+    }
+}

--- a/node/framework/src/config.rs
+++ b/node/framework/src/config.rs
@@ -1,0 +1,42 @@
+use vprogs_node_l1_bridge::L1BridgeConfig;
+use vprogs_scheduling_scheduler::ExecutionConfig;
+use vprogs_state_space::StateSpace;
+use vprogs_storage_manager::StorageConfig;
+use vprogs_storage_types::Store;
+
+use crate::NodeVm;
+
+/// Configuration for a [`Node`](crate::Node).
+///
+/// Wraps the sub-system configs and adds node-level settings. Use the `with_*` builder methods
+/// to override defaults.
+#[derive(Clone, Debug)]
+pub struct NodeConfig<S: Store<StateSpace = StateSpace>, V: NodeVm> {
+    /// Execution worker pool and VM configuration.
+    pub(crate) execution: ExecutionConfig<V>,
+    /// Storage backend and read/write configuration.
+    pub(crate) storage: StorageConfig<S>,
+    /// L1 bridge connection and sync configuration.
+    pub(crate) l1_bridge: L1BridgeConfig,
+    /// Bounded capacity of the [`NodeApi`](crate::NodeApi) request channel.
+    pub(crate) api_channel_capacity: usize,
+}
+
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeConfig<S, V> {
+    /// Creates a new config with the given sub-system configs and default node-level settings.
+    pub fn new(
+        execution: ExecutionConfig<V>,
+        storage: StorageConfig<S>,
+        l1_bridge: L1BridgeConfig,
+    ) -> Self {
+        Self { execution, storage, l1_bridge, api_channel_capacity: 64 }
+    }
+
+    /// Sets the bounded capacity of the [`NodeApi`](crate::NodeApi) request channel.
+    ///
+    /// Defaults to 64.
+    pub fn with_api_channel_capacity(mut self, capacity: usize) -> Self {
+        self.api_channel_capacity = capacity;
+        self
+    }
+}

--- a/node/framework/src/error.rs
+++ b/node/framework/src/error.rs
@@ -1,0 +1,13 @@
+/// Errors that can occur when communicating with the node worker via [`NodeApi`](crate::NodeApi).
+#[derive(Debug, thiserror::Error)]
+pub enum NodeError {
+    /// The request channel is closed - the worker thread has stopped.
+    #[error("node worker has stopped")]
+    WorkerStopped,
+    /// The request was sent but the worker dropped it without responding (e.g. during shutdown).
+    #[error("request was dropped by the worker without a response")]
+    RequestDropped,
+}
+
+/// Convenience alias for results returned by the node API.
+pub type NodeResult<T> = Result<T, NodeError>;

--- a/node/framework/src/lib.rs
+++ b/node/framework/src/lib.rs
@@ -1,0 +1,37 @@
+//! Generic node framework connecting the L1 bridge to the L2 scheduler.
+//!
+//! The framework orchestrates the flow of L1 chain blocks through pre-processing (translating
+//! blocks into L2 transactions) and scheduling (executing those transactions in parallel). Blocks
+//! are pre-processed out of order on execution workers but fed to the scheduler in sequence using
+//! async latches to preserve block ordering.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use vprogs_node_framework::{Node, NodeConfig};
+//!
+//! // Configure and start the node.
+//! let config = NodeConfig::new(execution_config, storage_config, l1_bridge_config);
+//! let node = Node::new(config);
+//!
+//! // Query the scheduler through the API.
+//! let checkpoint = node.api().last_committed().await?;
+//! let threshold = node.api().pruning_threshold().await?;
+//!
+//! // The node runs autonomously until shut down.
+//! node.shutdown();
+//! ```
+
+mod api;
+mod batch;
+mod config;
+mod error;
+mod node;
+mod vm;
+mod worker;
+
+pub use api::NodeApi;
+pub use config::NodeConfig;
+pub use error::{NodeError, NodeResult};
+pub use node::Node;
+pub use vm::NodeVm;

--- a/node/framework/src/lib.rs
+++ b/node/framework/src/lib.rs
@@ -14,9 +14,11 @@
 //! let config = NodeConfig::new(execution_config, storage_config, l1_bridge_config);
 //! let node = Node::new(config);
 //!
-//! // Query the scheduler through the API.
-//! let checkpoint = node.api().last_committed().await?;
-//! let threshold = node.api().pruning_threshold().await?;
+//! // Query state directly (lock-free, synchronous via SchedulerState deref).
+//! let checkpoint = node.api().last_committed();
+//!
+//! // Operations needing &mut Scheduler go through the worker thread.
+//! let threshold = node.api().with_scheduler(|s| s.pruning().threshold()).await?;
 //!
 //! // The node runs autonomously until shut down.
 //! node.shutdown();

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -38,9 +38,10 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
         let tip = scheduler.batch_execution().last_committed().clone();
         let bridge = L1Bridge::new(config.l1_bridge.with_root(Some(root)).with_tip(Some(tip)));
 
-        // Create the shutdown latch and API channel.
+        // Create the shutdown latch and the API.
         let shutdown = Arc::new(AtomicAsyncLatch::new());
         let (tx, rx) = mpsc::channel(config.api_channel_capacity);
+        let api = NodeApi::new(scheduler.state().clone(), tx);
 
         // Spawn the worker on a dedicated thread.
         let worker = NodeWorker::spawn(bridge, scheduler, rx, shutdown.clone());
@@ -53,7 +54,7 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
                     .block_on(worker)
             })),
             shutdown,
-            api: NodeApi(tx),
+            api,
         }
     }
 

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -17,7 +17,7 @@ use crate::{NodeVm, api::NodeApi, config::NodeConfig, worker::NodeWorker};
 /// Created via [`Node::new`], which starts all background components (bridge, scheduler, event
 /// loop). The node runs autonomously until [`shutdown`](Self::shutdown) is called.
 pub struct Node<S: Store<StateSpace = StateSpace>, V: NodeVm> {
-    /// Cloneable handle for querying the scheduler from outside the worker thread.
+    /// Cloneable handle for interacting with the node.
     api: NodeApi<S, V>,
     /// Worker thread running the event loop.
     handle: Option<JoinHandle<()>>,
@@ -58,7 +58,7 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
         }
     }
 
-    /// Returns a handle for querying the scheduler.
+    /// Returns a handle for interacting with the node.
     pub fn api(&self) -> &NodeApi<S, V> {
         &self.api
     }

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -31,13 +31,12 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
         // Create the scheduler - internally reads last checkpoint from store.
         let scheduler = Scheduler::new(config.execution, config.storage);
 
-        // Configure the bridge with resume state.
-        let bridge = L1Bridge::new(
-            config
-                .l1_bridge
-                .with_root(Some(scheduler.pruning().last_pruned()))
-                .with_tip(Some(scheduler.batch_execution().last_committed().clone())),
-        );
+        // Configure the bridge with resume state. Root is the oldest surviving batch
+        // (initialized on first commit, advanced on prune). On a fresh database both
+        // root and tip are default (index 0), so the bridge starts from genesis.
+        let root = scheduler.pruning().root();
+        let tip = scheduler.batch_execution().last_committed().clone();
+        let bridge = L1Bridge::new(config.l1_bridge.with_root(Some(root)).with_tip(Some(tip)));
 
         // Create the shutdown latch and API channel.
         let shutdown = Arc::new(AtomicAsyncLatch::new());

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -35,8 +35,8 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
         let bridge = L1Bridge::new(
             config
                 .l1_bridge
-                .with_root(Some(scheduler.pruning().last_pruned().into()))
-                .with_tip(Some(scheduler.batch_execution().last_committed().clone().into())),
+                .with_root(Some(scheduler.pruning().last_pruned()))
+                .with_tip(Some(scheduler.batch_execution().last_committed().clone())),
         );
 
         // Create the shutdown latch and API channel.

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -1,0 +1,84 @@
+use std::{
+    sync::Arc,
+    thread::{JoinHandle, spawn},
+};
+
+use tokio::{runtime::Builder, sync::mpsc};
+use vprogs_core_atomics::AtomicAsyncLatch;
+use vprogs_node_l1_bridge::L1Bridge;
+use vprogs_scheduling_scheduler::Scheduler;
+use vprogs_state_space::StateSpace;
+use vprogs_storage_types::Store;
+
+use crate::{NodeVm, api::NodeApi, config::NodeConfig, worker::NodeWorker};
+
+/// A running node that processes L1 chain blocks through the L2 scheduler.
+///
+/// Created via [`Node::new`], which starts all background components (bridge, scheduler, event
+/// loop). The node runs autonomously until [`shutdown`](Self::shutdown) is called.
+pub struct Node<S: Store<StateSpace = StateSpace>, V: NodeVm> {
+    /// Cloneable handle for querying the scheduler from outside the worker thread.
+    api: NodeApi<S, V>,
+    /// Worker thread running the event loop.
+    handle: Option<JoinHandle<()>>,
+    /// Signal to stop the event loop.
+    shutdown: Arc<AtomicAsyncLatch>,
+}
+
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
+    /// Creates and starts a new node.
+    pub fn new(config: NodeConfig<S, V>) -> Self {
+        // Create the scheduler - internally reads last checkpoint from store.
+        let scheduler = Scheduler::new(config.execution, config.storage);
+
+        // Configure the bridge with resume state.
+        let bridge = L1Bridge::new(
+            config
+                .l1_bridge
+                .with_root(Some(scheduler.pruning().last_pruned().into()))
+                .with_tip(Some(scheduler.batch_execution().last_committed().clone().into())),
+        );
+
+        // Create the shutdown latch and API channel.
+        let shutdown = Arc::new(AtomicAsyncLatch::new());
+        let (tx, rx) = mpsc::channel(config.api_channel_capacity);
+
+        // Spawn the worker on a dedicated thread.
+        let worker = NodeWorker::spawn(bridge, scheduler, rx, shutdown.clone());
+        Self {
+            handle: Some(spawn(move || {
+                Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build tokio runtime")
+                    .block_on(worker)
+            })),
+            shutdown,
+            api: NodeApi(tx),
+        }
+    }
+
+    /// Returns a handle for querying the scheduler.
+    pub fn api(&self) -> &NodeApi<S, V> {
+        &self.api
+    }
+
+    /// Shuts down the node and all its components.
+    ///
+    /// Signals the event loop to stop, then waits for the worker thread to finish. The worker
+    /// shuts down the bridge and scheduler in order before exiting.
+    pub fn shutdown(mut self) {
+        self.shutdown.open();
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("node worker panicked");
+        }
+    }
+}
+
+/// Ensures the worker thread receives a shutdown signal even if the node is dropped without an
+/// explicit [`shutdown`] call.
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Drop for Node<S, V> {
+    fn drop(&mut self) {
+        self.shutdown.open();
+    }
+}

--- a/node/framework/src/node.rs
+++ b/node/framework/src/node.rs
@@ -34,8 +34,8 @@ impl<S: Store<StateSpace = StateSpace>, V: NodeVm> Node<S, V> {
         // Configure the bridge with resume state. Root is the oldest surviving batch
         // (initialized on first commit, advanced on prune). On a fresh database both
         // root and tip are default (index 0), so the bridge starts from genesis.
-        let root = scheduler.pruning().root();
-        let tip = scheduler.batch_execution().last_committed().clone();
+        let root = (*scheduler.state().root()).clone();
+        let tip = (*scheduler.state().last_committed()).clone();
         let bridge = L1Bridge::new(config.l1_bridge.with_root(Some(root)).with_tip(Some(tip)));
 
         // Create the shutdown latch and the API.

--- a/node/framework/src/vm.rs
+++ b/node/framework/src/vm.rs
@@ -1,0 +1,20 @@
+use vprogs_node_l1_bridge::{ChainBlockMetadata, RpcOptionalHeader, RpcOptionalTransaction};
+use vprogs_scheduling_scheduler::VmInterface;
+
+/// Extension of [`VmInterface`] with L1 block pre-processing.
+///
+/// Implementors translate an L1 chain block (header + accepted transactions) into a batch of L2
+/// transactions. This runs on an execution worker thread and may complete out of order relative to
+/// block index.
+pub trait NodeVm: VmInterface<BatchMetadata = ChainBlockMetadata> {
+    /// Translates an L1 chain block into L2 transactions.
+    ///
+    /// Called on an execution worker thread. The returned transactions are later fed to the
+    /// scheduler in index order.
+    fn pre_process_block(
+        &self,
+        index: u64,
+        header: &RpcOptionalHeader,
+        accepted_transactions: &[RpcOptionalTransaction],
+    ) -> Vec<Self::Transaction>;
+}

--- a/node/framework/src/worker.rs
+++ b/node/framework/src/worker.rs
@@ -1,0 +1,166 @@
+use std::{collections::VecDeque, future::pending, sync::Arc};
+
+use tokio::sync::mpsc;
+use vprogs_core_atomics::AtomicAsyncLatch;
+use vprogs_node_l1_bridge::{L1Bridge, L1Event};
+use vprogs_scheduling_scheduler::Scheduler;
+use vprogs_state_space::StateSpace;
+use vprogs_storage_types::Store;
+
+use crate::{NodeVm, api::ApiRequest, batch::Batch};
+
+/// Owns the scheduler and bridge, processing L1 events through the L2 scheduler.
+///
+/// Consumes [`L1Event`]s from the bridge, dispatches pre-processing to execution workers, and feeds
+/// completed batches to the scheduler in order.
+pub(crate) struct NodeWorker<S: Store<StateSpace = StateSpace>, V: NodeVm> {
+    /// L1 chain event source - the primary data entry point into the node.
+    bridge: L1Bridge,
+    /// L2 transaction scheduler and execution engine.
+    scheduler: Scheduler<S, V>,
+    /// Incoming [`NodeApi`](crate::NodeApi) requests.
+    api_requests: mpsc::Receiver<ApiRequest<S, V>>,
+    /// Batches awaiting pre-processing completion, ordered by block index.
+    pending_batches: VecDeque<Arc<Batch<V>>>,
+    /// Signal to stop the event loop.
+    shutdown: Arc<AtomicAsyncLatch>,
+}
+
+impl<S: Store<StateSpace = StateSpace>, V: NodeVm> NodeWorker<S, V> {
+    /// Creates the worker and runs the event loop until shutdown is signaled or a fatal error
+    /// occurs. Shuts down the bridge and scheduler before returning.
+    pub(crate) async fn spawn(
+        bridge: L1Bridge,
+        scheduler: Scheduler<S, V>,
+        api_requests: mpsc::Receiver<ApiRequest<S, V>>,
+        shutdown: Arc<AtomicAsyncLatch>,
+    ) {
+        let pending_batches = VecDeque::new();
+        Self { bridge, scheduler, api_requests, pending_batches, shutdown }.run().await;
+    }
+
+    /// Priority-based event loop: shutdown > next batch prepared > API request > bridge event.
+    async fn run(mut self) {
+        loop {
+            // Feed all consecutively prepared batches into the scheduler before blocking.
+            self.process_prepared_batches();
+
+            // Biased select ensures priority ordering: we always check shutdown first, then
+            // whether the next in-order batch has finished pre-processing, then API requests,
+            // and finally new bridge events.
+            tokio::select! {
+                biased;
+
+                // Highest priority: exit the loop immediately on shutdown signal.
+                () = self.shutdown.wait() => break,
+
+                // A pending batch just finished pre-processing - loop back to process it.
+                () = async {
+                    if let Some(batch) = self.pending_batches.front() {
+                        batch.wait_until_prepared().await;
+                    } else {
+                        // No pending batches - pend forever to disable this branch.
+                        pending::<()>().await;
+                    }
+                } => continue,
+
+                // Execute an API request closure against the scheduler.
+                Some(api_request) = self.api_requests.recv() => {
+                    api_request(&mut self.scheduler);
+                }
+
+                // Process the next L1 bridge event (new block, rollback, etc.).
+                event = self.bridge.wait_and_pop() => {
+                    if !self.handle_event(event) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Shutdown sequence: stop the bridge first (no more events), then the scheduler.
+        self.bridge.shutdown();
+        self.scheduler.shutdown();
+    }
+
+    /// Processes all prepared batches from the front of the queue and schedules them.
+    ///
+    /// Stops at the first unprepared batch to preserve block ordering.
+    fn process_prepared_batches(&mut self) {
+        while let Some(batch) = self.pending_batches.front() {
+            if !batch.is_prepared() {
+                // Next batch is still being pre-processed - stop here to preserve ordering.
+                break;
+            }
+
+            // Take the prepared batch out of the queue and extract its results.
+            let batch = self.pending_batches.pop_front().expect("batch should exist");
+            let (txs, metadata) = batch.take();
+
+            // Feed the transactions into the scheduler for parallel execution.
+            self.scheduler.schedule(metadata, txs);
+        }
+    }
+
+    /// Dispatches a single bridge event. Returns `false` if the event loop should exit.
+    fn handle_event(&mut self, event: L1Event) -> bool {
+        match event {
+            L1Event::Connected => {
+                log::info!("L1 bridge connected");
+            }
+
+            L1Event::Disconnected => {
+                log::warn!("L1 bridge disconnected");
+            }
+
+            L1Event::ChainBlockAdded { checkpoint, header, accepted_transactions } => {
+                let index = checkpoint.index();
+                let batch = Batch::new(index);
+
+                // Submit pre-processing to an execution worker. The closure captures the VM
+                // and batch handle so it can run independently on the thread pool.
+                self.scheduler.submit_function({
+                    let vm = self.scheduler.vm().clone();
+                    let batch = batch.clone();
+                    move || {
+                        let txs = vm.pre_process_block(index, &header, &accepted_transactions);
+                        batch.set(txs, *checkpoint.metadata());
+                    }
+                });
+
+                // Enqueue the batch - it will be processed once pre-processing completes.
+                self.pending_batches.push_back(batch);
+            }
+
+            L1Event::Rollback { checkpoint, .. } => {
+                // Discard any in-flight batches beyond the rollback target. These may still
+                // be pre-processing on worker threads but their results will be ignored.
+                while let Some(batch) = self.pending_batches.back() {
+                    if batch.index() > checkpoint.index() {
+                        self.pending_batches.pop_back();
+                    } else {
+                        break;
+                    }
+                }
+
+                // Roll back the scheduler's committed state to the target index.
+                if let Err(e) = self.scheduler.rollback_to(checkpoint.index()) {
+                    log::error!("rollback to {} failed: {e}", checkpoint.index());
+                    return false;
+                }
+            }
+
+            L1Event::Finalized(block) => {
+                // Advance the pruning threshold - state below this index can be pruned.
+                self.scheduler.pruning().set_threshold(block.index());
+            }
+
+            L1Event::Fatal { reason } => {
+                log::error!("L1 bridge fatal error: {reason}");
+                return false;
+            }
+        }
+
+        true
+    }
+}

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -35,9 +35,9 @@ async fn mine_l2_blocks(l1: &L1Node, count: usize) -> u64 {
 }
 
 /// Asserts that L2 state was written for transactions 1..=count.
-async fn assert_l2_state(node: &Node<RocksDbStore, TestNodeVm>, count: usize) {
+fn assert_l2_state(node: &Node<RocksDbStore, TestNodeVm>, count: usize) {
     for i in 1..=count {
-        node.api().assert_written_state(i, vec![i]).await;
+        node.api().assert_written_state(i, vec![i]);
     }
 }
 
@@ -52,8 +52,8 @@ async fn test_basic_block_processing() {
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
-    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
-    assert_l2_state(&node, 3).await;
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT);
+    assert_l2_state(&node, 3);
 
     node.shutdown();
     l1.shutdown().await;
@@ -73,8 +73,8 @@ async fn test_processes_blocks_mined_after_connect() {
     let maturity = l1.mine_utxos(3).await.len() as u64;
     let payload_blocks = mine_l2_blocks(&l1, 3).await;
 
-    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
-    assert_l2_state(&node, 3).await;
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT);
+    assert_l2_state(&node, 3);
 
     node.shutdown();
     l1.shutdown().await;
@@ -94,7 +94,7 @@ async fn test_pruning_via_threshold() {
     let maturity = l1.mine_utxos(3).await.len() as u64;
     let payload_blocks = mine_l2_blocks(&l1, 3).await;
     let total = maturity + payload_blocks;
-    node.api().wait_committed(total, TIMEOUT).await;
+    node.api().wait_committed(total, TIMEOUT);
 
     // Set pruning threshold so early batches become eligible for pruning.
     let keep = total - 4;
@@ -103,13 +103,13 @@ async fn test_pruning_via_threshold() {
         .await
         .expect("api call failed");
 
-    node.api().wait_pruned(4, TIMEOUT).await;
+    node.api().wait_pruned(4, TIMEOUT);
 
     let root = node.api().root();
     assert!(root.index() > 4, "Expected root > 4, got {}", root.index());
 
     // L2 state written after the prune point must still be readable.
-    assert_l2_state(&node, 3).await;
+    assert_l2_state(&node, 3);
 
     node.shutdown();
     l1.shutdown().await;
@@ -125,8 +125,8 @@ async fn test_clean_shutdown() {
     let maturity = l1.mine_utxos(2).await.len() as u64;
     let payload_blocks = mine_l2_blocks(&l1, 2).await;
 
-    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
-    assert_l2_state(&node, 2).await;
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT);
+    assert_l2_state(&node, 2);
 
     // Shutdown should not panic.
     node.shutdown();
@@ -147,9 +147,9 @@ async fn test_resume_from_checkpoint() {
         let maturity = l1.mine_utxos(3).await.len() as u64;
         let payload_blocks = mine_l2_blocks(&l1, 3).await;
         phase1_total = maturity + payload_blocks;
-        node.api().wait_committed(phase1_total, TIMEOUT).await;
+        node.api().wait_committed(phase1_total, TIMEOUT);
 
-        assert_l2_state(&node, 3).await;
+        assert_l2_state(&node, 3);
 
         node.shutdown();
     }
@@ -172,10 +172,10 @@ async fn test_resume_from_checkpoint() {
 
     {
         let node = create_node(&l1, &temp_dir);
-        node.api().wait_committed(phase1_total + 5, TIMEOUT).await;
+        node.api().wait_committed(phase1_total + 5, TIMEOUT);
 
         // L2 state from phase 1 must survive the restart.
-        assert_l2_state(&node, 3).await;
+        assert_l2_state(&node, 3);
 
         node.shutdown();
     }
@@ -194,7 +194,7 @@ async fn test_l2_transactions_via_l1_payload() {
     // Mine enough blocks so coinbase UTXOs reach maturity (1 UTXO needed).
     let maturity_hashes = l1.mine_utxos(1).await;
     let maturity_blocks = maturity_hashes.len() as u64;
-    node.api().wait_committed(maturity_blocks, Duration::from_secs(120)).await;
+    node.api().wait_committed(maturity_blocks, Duration::from_secs(120));
 
     // Submit an L2 transaction via L1 payload.
     l1.mine_block(Some(&[Tx(42, vec![Access::Write(42)])])).await;
@@ -202,10 +202,10 @@ async fn test_l2_transactions_via_l1_payload() {
     // In Kaspa DAG consensus, a block's transactions are accepted by the next chain
     // block. Mine one more block so the payload transactions get accepted.
     l1.mine_blocks(1).await;
-    node.api().wait_committed(maturity_blocks + 2, Duration::from_secs(30)).await;
+    node.api().wait_committed(maturity_blocks + 2, Duration::from_secs(30));
 
     // Verify L2 state: resource 42 was written by tx id 42.
-    node.api().assert_written_state(42, vec![42]).await;
+    node.api().assert_written_state(42, vec![42]);
 
     node.shutdown();
     l1.shutdown().await;

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -1,0 +1,172 @@
+use std::time::Duration;
+
+use tempfile::TempDir;
+use vprogs_node_framework::{Node, NodeConfig};
+use vprogs_node_l1_bridge::{L1BridgeConfig, NetworkType};
+use vprogs_node_test_suite::{L1Node, NodeExt, TestNodeVm};
+use vprogs_scheduling_scheduler::ExecutionConfig;
+use vprogs_state_metadata::StateMetadata;
+use vprogs_storage_manager::StorageConfig;
+use vprogs_storage_rocksdb_store::RocksDbStore;
+
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Creates a Node connected to the given L1 simnet node using a temporary RocksDB store.
+fn create_node(l1: &L1Node, temp_dir: &TempDir) -> Node<RocksDbStore, TestNodeVm> {
+    let store = RocksDbStore::open(temp_dir.path());
+    Node::new(NodeConfig::new(
+        ExecutionConfig::default().with_vm(TestNodeVm),
+        StorageConfig::default().with_store(store),
+        L1BridgeConfig::default()
+            .with_url(l1.wrpc_borsh_url())
+            .with_network_type(NetworkType::Simnet),
+    ))
+}
+
+/// Mine blocks before creating the Node, then verify they are all processed.
+#[tokio::test]
+async fn test_basic_block_processing() {
+    let l1 = L1Node::new().await;
+    l1.mine_blocks(5).await;
+
+    let temp_dir = TempDir::new().unwrap();
+    let node = create_node(&l1, &temp_dir);
+
+    node.api().wait_committed(5, TIMEOUT).await;
+
+    // Each block produces at least one accepted transaction (coinbase).
+    // Verify at least one resource was written per block.
+    for block_index in 1..=5u64 {
+        let resource_id = block_index as usize * 1000;
+        node.api().assert_written_state(resource_id, vec![resource_id]).await;
+    }
+
+    node.shutdown();
+    l1.shutdown().await;
+}
+
+/// Create the node first, then mine blocks — verify real-time processing.
+#[tokio::test]
+async fn test_processes_blocks_mined_after_connect() {
+    let l1 = L1Node::new().await;
+
+    let temp_dir = TempDir::new().unwrap();
+    let node = create_node(&l1, &temp_dir);
+
+    // Give the bridge time to connect before mining.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    l1.mine_blocks(5).await;
+
+    node.api().wait_committed(5, TIMEOUT).await;
+
+    // Verify state for the first block.
+    let resource_id = 1000;
+    node.api().assert_written_state(resource_id, vec![resource_id]).await;
+
+    node.shutdown();
+    l1.shutdown().await;
+}
+
+/// Verify that pruning triggered via the scheduler works end-to-end.
+///
+/// Instead of relying on L1 finalization events (which require hundreds of simnet blocks),
+/// we manually set the pruning threshold through the API and verify the pruning worker
+/// processes it.
+#[tokio::test]
+async fn test_pruning_via_threshold() {
+    let l1 = L1Node::new().await;
+    l1.mine_blocks(10).await;
+
+    let temp_dir = TempDir::new().unwrap();
+    let node = create_node(&l1, &temp_dir);
+
+    node.api().wait_committed(10, TIMEOUT).await;
+
+    // Set pruning threshold so batches 1-4 become eligible for pruning.
+    node.api().with_scheduler(|s| s.pruning().set_threshold(5)).await.expect("api call failed");
+
+    // Wait for the pruning worker to process through index 4.
+    node.api().wait_pruned(4, TIMEOUT).await;
+
+    // Verify the pruned index is persisted.
+    let pruned = node.api().last_pruned().await.expect("api call failed");
+    assert!(pruned.index() >= 4, "Expected last_pruned >= 4, got {}", pruned.index());
+
+    node.shutdown();
+    l1.shutdown().await;
+}
+
+/// Verify the node shuts down cleanly without panics after processing blocks.
+#[tokio::test]
+async fn test_clean_shutdown() {
+    let l1 = L1Node::new().await;
+    l1.mine_blocks(3).await;
+
+    let temp_dir = TempDir::new().unwrap();
+    let node = create_node(&l1, &temp_dir);
+
+    node.api().wait_committed(3, TIMEOUT).await;
+
+    // Shutdown should not panic.
+    node.shutdown();
+    l1.shutdown().await;
+}
+
+/// Process blocks, shutdown, reopen from checkpoint, mine more, verify continuity.
+///
+/// Pruning must happen before shutdown so that `last_pruned` has a valid L1 block hash
+/// for the bridge to resume from.
+#[tokio::test]
+async fn test_resume_from_checkpoint() {
+    let l1 = L1Node::new().await;
+    l1.mine_blocks(10).await;
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // Phase 1: Process initial blocks, trigger pruning, then shutdown.
+    {
+        let node = create_node(&l1, &temp_dir);
+        node.api().wait_committed(10, TIMEOUT).await;
+
+        // Trigger pruning so last_pruned gets a valid L1 block hash. Without this,
+        // the bridge can't resume because the default root hash (0000...0000) doesn't
+        // exist in the L1 node.
+        node.api().with_scheduler(|s| s.pruning().set_threshold(5)).await.expect("api call failed");
+        node.api().wait_pruned(4, TIMEOUT).await;
+
+        node.shutdown();
+    }
+
+    // Verify checkpoints were persisted.
+    {
+        let store: RocksDbStore = RocksDbStore::open(temp_dir.path());
+        let committed: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
+            StateMetadata::last_committed(&store);
+        assert_eq!(committed.index(), 10, "Last committed index should be 10 after phase 1");
+
+        let pruned: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
+            StateMetadata::last_pruned(&store);
+        assert!(pruned.index() >= 4, "Last pruned should be >= 4 after phase 1");
+    }
+
+    // Phase 2: Mine more blocks and reopen — the node should resume from where it left off.
+    l1.mine_blocks(5).await;
+
+    {
+        let node = create_node(&l1, &temp_dir);
+        node.api().wait_committed(15, TIMEOUT).await;
+
+        // Verify state from phase 1 (block index 5, above pruning point).
+        let resource_id = 5000;
+        node.api().assert_written_state(resource_id, vec![resource_id]).await;
+
+        // Verify state from phase 2.
+        let resource_id = 11000;
+        node.api().assert_written_state(resource_id, vec![resource_id]).await;
+
+        node.shutdown();
+    }
+
+    l1.shutdown().await;
+}

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tempfile::TempDir;
 use vprogs_node_framework::{Node, NodeConfig};
 use vprogs_node_l1_bridge::{L1BridgeConfig, NetworkType};
-use vprogs_node_test_suite::{L1Node, NodeExt, TestNodeVm};
+use vprogs_node_test_suite::{Access, L1Node, NodeExt, TestNodeVm, Tx};
 use vprogs_scheduling_scheduler::ExecutionConfig;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_storage_manager::StorageConfig;
@@ -34,13 +34,6 @@ async fn test_basic_block_processing() {
 
     node.api().wait_committed(5, TIMEOUT).await;
 
-    // Each block produces at least one accepted transaction (coinbase).
-    // Verify at least one resource was written per block.
-    for block_index in 1..=5u64 {
-        let resource_id = block_index as usize * 1000;
-        node.api().assert_written_state(resource_id, vec![resource_id]).await;
-    }
-
     node.shutdown();
     l1.shutdown().await;
 }
@@ -60,10 +53,6 @@ async fn test_processes_blocks_mined_after_connect() {
 
     node.api().wait_committed(5, TIMEOUT).await;
 
-    // Verify state for the first block.
-    let resource_id = 1000;
-    node.api().assert_written_state(resource_id, vec![resource_id]).await;
-
     node.shutdown();
     l1.shutdown().await;
 }
@@ -76,11 +65,10 @@ async fn test_processes_blocks_mined_after_connect() {
 #[tokio::test]
 async fn test_pruning_via_threshold() {
     let l1 = L1Node::new().await;
-    l1.mine_blocks(10).await;
-
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
+    l1.mine_blocks(10).await;
     node.api().wait_committed(10, TIMEOUT).await;
 
     // Set pruning threshold so batches 1-4 become eligible for pruning.
@@ -101,11 +89,10 @@ async fn test_pruning_via_threshold() {
 #[tokio::test]
 async fn test_clean_shutdown() {
     let l1 = L1Node::new().await;
-    l1.mine_blocks(3).await;
-
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
+    l1.mine_blocks(3).await;
     node.api().wait_committed(3, TIMEOUT).await;
 
     // Shutdown should not panic.
@@ -120,13 +107,13 @@ async fn test_clean_shutdown() {
 #[tokio::test]
 async fn test_resume_from_checkpoint() {
     let l1 = L1Node::new().await;
-    l1.mine_blocks(10).await;
-
     let temp_dir = TempDir::new().unwrap();
 
     // Phase 1: Process initial blocks, trigger pruning, then shutdown.
     {
         let node = create_node(&l1, &temp_dir);
+
+        l1.mine_blocks(10).await;
         node.api().wait_committed(10, TIMEOUT).await;
 
         // Trigger pruning so last_pruned gets a valid L1 block hash. Without this,
@@ -157,16 +144,35 @@ async fn test_resume_from_checkpoint() {
         let node = create_node(&l1, &temp_dir);
         node.api().wait_committed(15, TIMEOUT).await;
 
-        // Verify state from phase 1 (block index 5, above pruning point).
-        let resource_id = 5000;
-        node.api().assert_written_state(resource_id, vec![resource_id]).await;
-
-        // Verify state from phase 2.
-        let resource_id = 11000;
-        node.api().assert_written_state(resource_id, vec![resource_id]).await;
-
         node.shutdown();
     }
 
+    l1.shutdown().await;
+}
+
+/// Submit L2 transactions via L1 payload and verify L2 state is written.
+#[tokio::test]
+async fn test_l2_transactions_via_l1_payload() {
+    let l1 = L1Node::new().await;
+    let temp_dir = TempDir::new().unwrap();
+    let node = create_node(&l1, &temp_dir);
+
+    // Mine enough blocks so coinbase UTXOs reach maturity (1 UTXO needed).
+    let maturity_hashes = l1.mine_utxos(1).await;
+    let maturity_blocks = maturity_hashes.len() as u64;
+    node.api().wait_committed(maturity_blocks, Duration::from_secs(120)).await;
+
+    // Submit an L2 transaction via L1 payload.
+    l1.mine_block(Some(&[Tx(42, vec![Access::Write(42)])])).await;
+
+    // In Kaspa DAG consensus, a block's transactions are accepted by the next chain
+    // block. Mine one more block so the payload transactions get accepted.
+    l1.mine_blocks(1).await;
+    node.api().wait_committed(maturity_blocks + 2, Duration::from_secs(30)).await;
+
+    // Verify L2 state: resource 42 was written by tx id 42.
+    node.api().assert_written_state(42, vec![42]).await;
+
+    node.shutdown();
     l1.shutdown().await;
 }

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -105,7 +105,7 @@ async fn test_pruning_via_threshold() {
 
     node.api().wait_pruned(4, TIMEOUT).await;
 
-    let root = node.api().root().await.expect("api call failed");
+    let root = node.api().root();
     assert!(root.index() > 4, "Expected root > 4, got {}", root.index());
 
     // L2 state written after the prune point must still be readable.

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -23,25 +23,46 @@ fn create_node(l1: &L1Node, temp_dir: &TempDir) -> Node<RocksDbStore, TestNodeVm
     ))
 }
 
-/// Mine blocks before creating the Node, then verify they are all processed.
+/// Mines L2 payload blocks and one acceptance block, returning the total number of blocks mined.
+async fn mine_l2_blocks(l1: &L1Node, count: usize) -> u64 {
+    for i in 1..=count {
+        l1.mine_block(Some(&[Tx(i, vec![Access::Write(i)])])).await;
+    }
+    // In Kaspa DAG consensus, a block's transactions are accepted by the next chain
+    // block. Mine one more so the last payload gets accepted.
+    l1.mine_blocks(1).await;
+    count as u64 + 1
+}
+
+/// Asserts that L2 state was written for transactions 1..=count.
+async fn assert_l2_state(node: &Node<RocksDbStore, TestNodeVm>, count: usize) {
+    for i in 1..=count {
+        node.api().assert_written_state(i, vec![i]).await;
+    }
+}
+
+/// Mine blocks with L2 payloads before creating the Node, then verify they are all processed.
 #[tokio::test]
 async fn test_basic_block_processing() {
-    let l1 = L1Node::new().await;
-    l1.mine_blocks(5).await;
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
+
+    let maturity = l1.mine_utxos(3).await.len() as u64;
+    let payload_blocks = mine_l2_blocks(&l1, 3).await;
 
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
-    node.api().wait_committed(5, TIMEOUT).await;
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
+    assert_l2_state(&node, 3).await;
 
     node.shutdown();
     l1.shutdown().await;
 }
 
-/// Create the node first, then mine blocks — verify real-time processing.
+/// Create the node first, then mine blocks with L2 payloads — verify real-time processing.
 #[tokio::test]
 async fn test_processes_blocks_mined_after_connect() {
-    let l1 = L1Node::new().await;
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
 
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
@@ -49,9 +70,11 @@ async fn test_processes_blocks_mined_after_connect() {
     // Give the bridge time to connect before mining.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    l1.mine_blocks(5).await;
+    let maturity = l1.mine_utxos(3).await.len() as u64;
+    let payload_blocks = mine_l2_blocks(&l1, 3).await;
 
-    node.api().wait_committed(5, TIMEOUT).await;
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
+    assert_l2_state(&node, 3).await;
 
     node.shutdown();
     l1.shutdown().await;
@@ -61,65 +84,84 @@ async fn test_processes_blocks_mined_after_connect() {
 ///
 /// Instead of relying on L1 finalization events (which require hundreds of simnet blocks),
 /// we manually set the pruning threshold through the API and verify the pruning worker
-/// processes it.
+/// processes it. L2 state written after the prune point must survive.
 #[tokio::test]
 async fn test_pruning_via_threshold() {
-    let l1 = L1Node::new().await;
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
-    l1.mine_blocks(10).await;
-    node.api().wait_committed(10, TIMEOUT).await;
+    let maturity = l1.mine_utxos(3).await.len() as u64;
+    let payload_blocks = mine_l2_blocks(&l1, 3).await;
+    let total = maturity + payload_blocks;
+    node.api().wait_committed(total, TIMEOUT).await;
 
-    // Set pruning threshold so batches 1-4 become eligible for pruning.
-    node.api().with_scheduler(|s| s.pruning().set_threshold(5)).await.expect("api call failed");
+    // Set pruning threshold so early batches become eligible for pruning.
+    let keep = total - 4;
+    node.api()
+        .with_scheduler(move |s| s.pruning().set_threshold(keep))
+        .await
+        .expect("api call failed");
 
-    // Wait for the pruning worker to process through index 4.
     node.api().wait_pruned(4, TIMEOUT).await;
 
-    // Verify the pruned index is persisted.
     let pruned = node.api().last_pruned().await.expect("api call failed");
     assert!(pruned.index() >= 4, "Expected last_pruned >= 4, got {}", pruned.index());
+
+    // L2 state written after the prune point must still be readable.
+    assert_l2_state(&node, 3).await;
 
     node.shutdown();
     l1.shutdown().await;
 }
 
-/// Verify the node shuts down cleanly without panics after processing blocks.
+/// Verify the node shuts down cleanly without panics after processing L2 state.
 #[tokio::test]
 async fn test_clean_shutdown() {
-    let l1 = L1Node::new().await;
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 
-    l1.mine_blocks(3).await;
-    node.api().wait_committed(3, TIMEOUT).await;
+    let maturity = l1.mine_utxos(2).await.len() as u64;
+    let payload_blocks = mine_l2_blocks(&l1, 2).await;
+
+    node.api().wait_committed(maturity + payload_blocks, TIMEOUT).await;
+    assert_l2_state(&node, 2).await;
 
     // Shutdown should not panic.
     node.shutdown();
     l1.shutdown().await;
 }
 
-/// Process blocks, shutdown, reopen from checkpoint, mine more, verify continuity.
+/// Process blocks with L2 state, shutdown, reopen from checkpoint, mine more, verify continuity.
 ///
 /// Pruning must happen before shutdown so that `last_pruned` has a valid L1 block hash
 /// for the bridge to resume from.
 #[tokio::test]
 async fn test_resume_from_checkpoint() {
-    let l1 = L1Node::new().await;
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
     let temp_dir = TempDir::new().unwrap();
 
-    // Phase 1: Process initial blocks, trigger pruning, then shutdown.
+    // Phase 1: Process L2 transactions, trigger pruning, then shutdown.
+    let phase1_total;
     {
         let node = create_node(&l1, &temp_dir);
 
-        l1.mine_blocks(10).await;
-        node.api().wait_committed(10, TIMEOUT).await;
+        let maturity = l1.mine_utxos(3).await.len() as u64;
+        let payload_blocks = mine_l2_blocks(&l1, 3).await;
+        phase1_total = maturity + payload_blocks;
+        node.api().wait_committed(phase1_total, TIMEOUT).await;
+
+        assert_l2_state(&node, 3).await;
 
         // Trigger pruning so last_pruned gets a valid L1 block hash. Without this,
         // the bridge can't resume because the default root hash (0000...0000) doesn't
         // exist in the L1 node.
-        node.api().with_scheduler(|s| s.pruning().set_threshold(5)).await.expect("api call failed");
+        let keep = phase1_total - 4;
+        node.api()
+            .with_scheduler(move |s| s.pruning().set_threshold(keep))
+            .await
+            .expect("api call failed");
         node.api().wait_pruned(4, TIMEOUT).await;
 
         node.shutdown();
@@ -130,7 +172,12 @@ async fn test_resume_from_checkpoint() {
         let store: RocksDbStore = RocksDbStore::open(temp_dir.path());
         let committed: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
             StateMetadata::last_committed(&store);
-        assert_eq!(committed.index(), 10, "Last committed index should be 10 after phase 1");
+        assert_eq!(
+            committed.index(),
+            phase1_total,
+            "Last committed index should be {} after phase 1",
+            phase1_total
+        );
 
         let pruned: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
             StateMetadata::last_pruned(&store);
@@ -142,7 +189,10 @@ async fn test_resume_from_checkpoint() {
 
     {
         let node = create_node(&l1, &temp_dir);
-        node.api().wait_committed(15, TIMEOUT).await;
+        node.api().wait_committed(phase1_total + 5, TIMEOUT).await;
+
+        // L2 state from phase 1 must survive the restart.
+        assert_l2_state(&node, 3).await;
 
         node.shutdown();
     }
@@ -153,7 +203,8 @@ async fn test_resume_from_checkpoint() {
 /// Submit L2 transactions via L1 payload and verify L2 state is written.
 #[tokio::test]
 async fn test_l2_transactions_via_l1_payload() {
-    let l1 = L1Node::new().await;
+    // Reduce coinbase maturity so mine_utxos doesn't need to mine 1000+ blocks.
+    let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
     let temp_dir = TempDir::new().unwrap();
     let node = create_node(&l1, &temp_dir);
 

--- a/node/framework/tests/e2e.rs
+++ b/node/framework/tests/e2e.rs
@@ -105,8 +105,8 @@ async fn test_pruning_via_threshold() {
 
     node.api().wait_pruned(4, TIMEOUT).await;
 
-    let pruned = node.api().last_pruned().await.expect("api call failed");
-    assert!(pruned.index() >= 4, "Expected last_pruned >= 4, got {}", pruned.index());
+    let root = node.api().root().await.expect("api call failed");
+    assert!(root.index() > 4, "Expected root > 4, got {}", root.index());
 
     // L2 state written after the prune point must still be readable.
     assert_l2_state(&node, 3).await;
@@ -134,15 +134,12 @@ async fn test_clean_shutdown() {
 }
 
 /// Process blocks with L2 state, shutdown, reopen from checkpoint, mine more, verify continuity.
-///
-/// Pruning must happen before shutdown so that `last_pruned` has a valid L1 block hash
-/// for the bridge to resume from.
 #[tokio::test]
 async fn test_resume_from_checkpoint() {
     let l1 = L1Node::new(Some(|p| p.blockrate.coinbase_maturity = 1)).await;
     let temp_dir = TempDir::new().unwrap();
 
-    // Phase 1: Process L2 transactions, trigger pruning, then shutdown.
+    // Phase 1: Process L2 transactions, then shutdown.
     let phase1_total;
     {
         let node = create_node(&l1, &temp_dir);
@@ -154,20 +151,10 @@ async fn test_resume_from_checkpoint() {
 
         assert_l2_state(&node, 3).await;
 
-        // Trigger pruning so last_pruned gets a valid L1 block hash. Without this,
-        // the bridge can't resume because the default root hash (0000...0000) doesn't
-        // exist in the L1 node.
-        let keep = phase1_total - 4;
-        node.api()
-            .with_scheduler(move |s| s.pruning().set_threshold(keep))
-            .await
-            .expect("api call failed");
-        node.api().wait_pruned(4, TIMEOUT).await;
-
         node.shutdown();
     }
 
-    // Verify checkpoints were persisted.
+    // Verify checkpoint was persisted.
     {
         let store: RocksDbStore = RocksDbStore::open(temp_dir.path());
         let committed: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
@@ -178,10 +165,6 @@ async fn test_resume_from_checkpoint() {
             "Last committed index should be {} after phase 1",
             phase1_total
         );
-
-        let pruned: vprogs_core_types::Checkpoint<vprogs_node_l1_bridge::ChainBlockMetadata> =
-            StateMetadata::last_pruned(&store);
-        assert!(pruned.index() >= 4, "Last pruned should be >= 4 after phase 1");
     }
 
     // Phase 2: Mine more blocks and reopen — the node should resume from where it left off.

--- a/node/test-suite/Cargo.toml
+++ b/node/test-suite/Cargo.toml
@@ -4,19 +4,27 @@ name              = "vprogs-node-test-suite"
 version.workspace = true
 
 [dependencies]
-borsh.workspace                     = true
-kaspa-addresses.workspace           = true
-kaspa-consensus-core.workspace      = true
-kaspa-core.workspace                = true
-kaspa-grpc-client.workspace         = true
-kaspa-rpc-core.workspace            = true
-kaspa-testing-integration.workspace = true
-kaspa-txscript.workspace            = true
-kaspa-wrpc-server.workspace         = true
-kaspad.workspace                    = true
-secp256k1.workspace                 = true
-serde_json.workspace                = true
-tap.workspace                       = true
-tempfile.workspace                  = true
-tokio                               = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
-vprogs-node-l1-bridge.workspace     = true
+borsh.workspace                        = true
+kaspa-addresses.workspace              = true
+kaspa-consensus-core.workspace         = true
+kaspa-core.workspace                   = true
+kaspa-grpc-client.workspace            = true
+kaspa-rpc-core.workspace               = true
+kaspa-testing-integration.workspace    = true
+kaspa-txscript.workspace               = true
+kaspa-wrpc-server.workspace            = true
+kaspad.workspace                       = true
+secp256k1.workspace                    = true
+serde_json.workspace                   = true
+tempfile.workspace                     = true
+tokio                                  = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+vprogs-core-types.workspace            = true
+vprogs-node-framework.workspace        = true
+vprogs-node-l1-bridge.workspace        = true
+vprogs-scheduling-scheduler.workspace  = true
+vprogs-scheduling-test-suite.workspace = true
+vprogs-state-metadata.workspace        = true
+vprogs-state-space.workspace           = true
+vprogs-state-version.workspace         = true
+vprogs-storage-rocksdb-store.workspace = true
+vprogs-storage-types.workspace         = true

--- a/node/test-suite/Cargo.toml
+++ b/node/test-suite/Cargo.toml
@@ -16,6 +16,7 @@ kaspa-wrpc-server.workspace            = true
 kaspad.workspace                       = true
 secp256k1.workspace                    = true
 serde_json.workspace                   = true
+tap.workspace                          = true
 tempfile.workspace                     = true
 tokio                                  = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 vprogs-core-types.workspace            = true

--- a/node/test-suite/src/lib.rs
+++ b/node/test-suite/src/lib.rs
@@ -41,6 +41,8 @@
 
 mod l1_bridge_ext;
 mod l1_node;
+mod node_ext;
+mod vm;
 
 pub use kaspa_consensus_core::{
     Hash,
@@ -48,3 +50,6 @@ pub use kaspa_consensus_core::{
 };
 pub use l1_bridge_ext::L1BridgeExt;
 pub use l1_node::L1Node;
+pub use node_ext::NodeExt;
+pub use vm::TestNodeVm;
+pub use vprogs_scheduling_test_suite::{Access, Tx};

--- a/node/test-suite/src/node_ext.rs
+++ b/node/test-suite/src/node_ext.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 use vprogs_node_framework::NodeApi;
 use vprogs_node_l1_bridge::ChainBlockMetadata;
@@ -12,110 +15,80 @@ use crate::TestNodeVm;
 
 /// Convenience helpers for [`NodeApi`] in test scenarios.
 pub trait NodeExt {
-    /// Polls until `last_committed` index reaches `expected`, or panics on timeout.
-    fn wait_committed(
-        &self,
-        expected: u64,
-        timeout: Duration,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    /// Blocks until `last_committed` index reaches `expected`, or panics on timeout.
+    fn wait_committed(&self, expected: u64, timeout: Duration);
 
-    /// Polls until pruning has progressed past `expected` (root index > expected), or panics on
+    /// Blocks until pruning has progressed past `expected` (root index > expected), or panics on
     /// timeout.
-    fn wait_pruned(
-        &self,
-        expected: u64,
-        timeout: Duration,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    fn wait_pruned(&self, expected: u64, timeout: Duration);
 
     /// Asserts that a resource was written by the given writer IDs (in order).
-    fn assert_written_state(
-        &self,
-        resource_id: usize,
-        writers: Vec<usize>,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    fn assert_written_state(&self, resource_id: usize, writers: Vec<usize>);
 
     /// Asserts that a resource has been deleted (no latest pointer exists).
-    fn assert_resource_deleted(
-        &self,
-        resource_id: usize,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    fn assert_resource_deleted(&self, resource_id: usize);
 }
 
 impl NodeExt for NodeApi<RocksDbStore, TestNodeVm> {
-    async fn wait_committed(&self, expected: u64, timeout: Duration) {
-        let deadline = tokio::time::Instant::now() + timeout;
+    fn wait_committed(&self, expected: u64, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
         loop {
             // Read the persisted value from disk, because the in-memory last_committed
             // is lazily updated only when the next batch is scheduled.
-            let index = self
-                .with_scheduler(|scheduler| {
-                    StateMetadata::last_committed::<ChainBlockMetadata, _>(
-                        &**scheduler.storage().store(),
-                    )
-                    .index()
-                })
-                .await
-                .expect("api call failed");
+            let index =
+                StateMetadata::last_committed::<ChainBlockMetadata, _>(&**self.storage().store())
+                    .index();
             if index >= expected {
                 return;
             }
             assert!(
-                tokio::time::Instant::now() < deadline,
+                Instant::now() < deadline,
                 "Timeout waiting for committed index >= {expected}, got {index}",
             );
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            thread::sleep(Duration::from_millis(100));
         }
     }
 
-    async fn wait_pruned(&self, expected: u64, timeout: Duration) {
-        let deadline = tokio::time::Instant::now() + timeout;
+    fn wait_pruned(&self, expected: u64, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
         loop {
             let root_index = self.root().index();
             if root_index > expected {
                 return;
             }
             assert!(
-                tokio::time::Instant::now() < deadline,
+                Instant::now() < deadline,
                 "Timeout waiting for root index > {expected}, got {root_index}",
             );
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            thread::sleep(Duration::from_millis(100));
         }
     }
 
-    async fn assert_written_state(&self, resource_id: usize, writers: Vec<usize>) {
-        self.with_scheduler(move |scheduler| {
-            let store = scheduler.storage().store();
-            let writer_count = writers.len();
-            let writer_log: Vec<u8> = writers.iter().flat_map(|id| id.to_be_bytes()).collect();
+    fn assert_written_state(&self, resource_id: usize, writers: Vec<usize>) {
+        let store = self.storage().store();
+        let writer_count = writers.len();
+        let writer_log: Vec<u8> = writers.iter().flat_map(|id| id.to_be_bytes()).collect();
 
-            let versioned_state =
-                StateVersion::<usize>::from_latest_data(store.as_ref(), resource_id);
-            assert_eq!(
-                versioned_state.version(),
-                writer_count as u64,
-                "resource {resource_id}: expected version {writer_count}, got {}",
-                versioned_state.version()
-            );
-            assert_eq!(
-                *versioned_state.data(),
-                writer_log,
-                "resource {resource_id}: unexpected writer log"
-            );
-        })
-        .await
-        .expect("api call failed");
+        let versioned_state = StateVersion::<usize>::from_latest_data(store.as_ref(), resource_id);
+        assert_eq!(
+            versioned_state.version(),
+            writer_count as u64,
+            "resource {resource_id}: expected version {writer_count}, got {}",
+            versioned_state.version()
+        );
+        assert_eq!(
+            *versioned_state.data(),
+            writer_log,
+            "resource {resource_id}: unexpected writer log"
+        );
     }
 
-    async fn assert_resource_deleted(&self, resource_id: usize) {
-        self.with_scheduler(move |scheduler| {
-            let store = scheduler.storage().store();
-            let id_bytes = resource_id.to_be_bytes();
-            assert!(
-                store.get(StateSpace::StatePtrLatest, &id_bytes).is_none(),
-                "Resource {resource_id} should have been deleted but still exists",
-            );
-        })
-        .await
-        .expect("api call failed");
+    fn assert_resource_deleted(&self, resource_id: usize) {
+        let store = self.storage().store();
+        let id_bytes = resource_id.to_be_bytes();
+        assert!(
+            store.get(StateSpace::StatePtrLatest, &id_bytes).is_none(),
+            "Resource {resource_id} should have been deleted but still exists",
+        );
     }
 }

--- a/node/test-suite/src/node_ext.rs
+++ b/node/test-suite/src/node_ext.rs
@@ -70,10 +70,7 @@ impl NodeExt for NodeApi<RocksDbStore, TestNodeVm> {
     async fn wait_pruned(&self, expected: u64, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let root_index = self
-                .with_scheduler(|scheduler| scheduler.pruning().root().index())
-                .await
-                .expect("api call failed");
+            let root_index = self.root().index();
             if root_index > expected {
                 return;
             }

--- a/node/test-suite/src/node_ext.rs
+++ b/node/test-suite/src/node_ext.rs
@@ -1,0 +1,123 @@
+use std::time::Duration;
+
+use vprogs_node_framework::NodeApi;
+use vprogs_node_l1_bridge::ChainBlockMetadata;
+use vprogs_state_metadata::StateMetadata;
+use vprogs_state_space::StateSpace;
+use vprogs_state_version::StateVersion;
+use vprogs_storage_rocksdb_store::RocksDbStore;
+use vprogs_storage_types::ReadStore;
+
+use crate::TestNodeVm;
+
+/// Convenience helpers for [`NodeApi`] in test scenarios.
+pub trait NodeExt {
+    /// Polls until `last_committed` index reaches `expected`, or panics on timeout.
+    fn wait_committed(
+        &self,
+        expected: u64,
+        timeout: Duration,
+    ) -> impl std::future::Future<Output = ()> + Send;
+
+    /// Polls until `last_pruned` index reaches `expected`, or panics on timeout.
+    fn wait_pruned(
+        &self,
+        expected: u64,
+        timeout: Duration,
+    ) -> impl std::future::Future<Output = ()> + Send;
+
+    /// Asserts that a resource was written by the given writer IDs (in order).
+    fn assert_written_state(
+        &self,
+        resource_id: usize,
+        writers: Vec<usize>,
+    ) -> impl std::future::Future<Output = ()> + Send;
+
+    /// Asserts that a resource has been deleted (no latest pointer exists).
+    fn assert_resource_deleted(
+        &self,
+        resource_id: usize,
+    ) -> impl std::future::Future<Output = ()> + Send;
+}
+
+impl NodeExt for NodeApi<RocksDbStore, TestNodeVm> {
+    async fn wait_committed(&self, expected: u64, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // Read the persisted value from disk, because the in-memory last_committed
+            // is lazily updated only when the next batch is scheduled.
+            let index = self
+                .with_scheduler(|scheduler| {
+                    StateMetadata::last_committed::<ChainBlockMetadata, _>(
+                        &**scheduler.storage().store(),
+                    )
+                    .index()
+                })
+                .await
+                .expect("api call failed");
+            if index >= expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timeout waiting for committed index >= {expected}, got {index}",
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn wait_pruned(&self, expected: u64, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let index = self
+                .with_scheduler(|scheduler| scheduler.pruning().last_pruned().index())
+                .await
+                .expect("api call failed");
+            if index >= expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timeout waiting for pruned index >= {expected}, got {index}",
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn assert_written_state(&self, resource_id: usize, writers: Vec<usize>) {
+        self.with_scheduler(move |scheduler| {
+            let store = scheduler.storage().store();
+            let writer_count = writers.len();
+            let writer_log: Vec<u8> = writers.iter().flat_map(|id| id.to_be_bytes()).collect();
+
+            let versioned_state =
+                StateVersion::<usize>::from_latest_data(store.as_ref(), resource_id);
+            assert_eq!(
+                versioned_state.version(),
+                writer_count as u64,
+                "resource {resource_id}: expected version {writer_count}, got {}",
+                versioned_state.version()
+            );
+            assert_eq!(
+                *versioned_state.data(),
+                writer_log,
+                "resource {resource_id}: unexpected writer log"
+            );
+        })
+        .await
+        .expect("api call failed");
+    }
+
+    async fn assert_resource_deleted(&self, resource_id: usize) {
+        self.with_scheduler(move |scheduler| {
+            let store = scheduler.storage().store();
+            let id_bytes = resource_id.to_be_bytes();
+            assert!(
+                store.get(StateSpace::StatePtrLatest, &id_bytes).is_none(),
+                "Resource {resource_id} should have been deleted but still exists",
+            );
+        })
+        .await
+        .expect("api call failed");
+    }
+}

--- a/node/test-suite/src/node_ext.rs
+++ b/node/test-suite/src/node_ext.rs
@@ -19,7 +19,8 @@ pub trait NodeExt {
         timeout: Duration,
     ) -> impl std::future::Future<Output = ()> + Send;
 
-    /// Polls until `last_pruned` index reaches `expected`, or panics on timeout.
+    /// Polls until pruning has progressed past `expected` (root index > expected), or panics on
+    /// timeout.
     fn wait_pruned(
         &self,
         expected: u64,
@@ -69,16 +70,16 @@ impl NodeExt for NodeApi<RocksDbStore, TestNodeVm> {
     async fn wait_pruned(&self, expected: u64, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let index = self
-                .with_scheduler(|scheduler| scheduler.pruning().last_pruned().index())
+            let root_index = self
+                .with_scheduler(|scheduler| scheduler.pruning().root().index())
                 .await
                 .expect("api call failed");
-            if index >= expected {
+            if root_index > expected {
                 return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "Timeout waiting for pruned index >= {expected}, got {index}",
+                "Timeout waiting for root index > {expected}, got {root_index}",
             );
             tokio::time::sleep(Duration::from_millis(100)).await;
         }

--- a/node/test-suite/src/vm.rs
+++ b/node/test-suite/src/vm.rs
@@ -1,0 +1,63 @@
+use vprogs_core_types::{AccessMetadata, AccessType};
+use vprogs_node_framework::NodeVm;
+use vprogs_node_l1_bridge::{ChainBlockMetadata, RpcOptionalHeader, RpcOptionalTransaction};
+use vprogs_scheduling_scheduler::{AccessHandle, RuntimeBatch, VmInterface};
+use vprogs_scheduling_test_suite::{Access, Tx};
+use vprogs_state_space::StateSpace;
+use vprogs_storage_types::Store;
+
+/// A minimal VM implementing [`NodeVm`] for testing the node framework.
+#[derive(Clone)]
+pub struct TestNodeVm;
+
+impl VmInterface for TestNodeVm {
+    type Transaction = Tx;
+    type TransactionEffects = ();
+    type ResourceId = usize;
+    type AccessMetadata = Access;
+    type BatchMetadata = ChainBlockMetadata;
+    type Error = ();
+
+    fn process_transaction<S: Store<StateSpace = StateSpace>>(
+        &self,
+        tx: &Self::Transaction,
+        resources: &mut [AccessHandle<S, Self>],
+    ) -> Result<(), Self::Error> {
+        for resource in resources {
+            if resource.access_metadata().access_type() == AccessType::Write {
+                resource.data_mut().extend_from_slice(&tx.0.to_be_bytes());
+            }
+        }
+        Ok(())
+    }
+
+    fn post_process_batch<S: Store<StateSpace = StateSpace>>(&self, batch: &RuntimeBatch<S, Self>) {
+        if !batch.was_canceled() {
+            eprintln!(
+                ">> Processed batch with {} transactions and {} state changes",
+                batch.txs().len(),
+                batch.state_diffs().len()
+            );
+        }
+    }
+}
+
+impl NodeVm for TestNodeVm {
+    fn pre_process_block(
+        &self,
+        index: u64,
+        _header: &RpcOptionalHeader,
+        accepted_transactions: &[RpcOptionalTransaction],
+    ) -> Vec<Tx> {
+        // Each accepted L1 tx becomes a deterministic L2 write.
+        // resource_id = block_index * 1000 + position_in_block
+        accepted_transactions
+            .iter()
+            .enumerate()
+            .map(|(i, _)| {
+                let resource_id = index as usize * 1000 + i;
+                Tx(resource_id, vec![Access::Write(resource_id)])
+            })
+            .collect()
+    }
+}

--- a/node/test-suite/src/vm.rs
+++ b/node/test-suite/src/vm.rs
@@ -1,3 +1,4 @@
+use borsh::BorshDeserialize;
 use vprogs_core_types::{AccessMetadata, AccessType};
 use vprogs_node_framework::NodeVm;
 use vprogs_node_l1_bridge::{ChainBlockMetadata, RpcOptionalHeader, RpcOptionalTransaction};
@@ -10,14 +11,21 @@ use vprogs_storage_types::Store;
 #[derive(Clone)]
 pub struct TestNodeVm;
 
-impl VmInterface for TestNodeVm {
-    type Transaction = Tx;
-    type TransactionEffects = ();
-    type ResourceId = usize;
-    type AccessMetadata = Access;
-    type BatchMetadata = ChainBlockMetadata;
-    type Error = ();
+impl NodeVm for TestNodeVm {
+    fn pre_process_block(
+        &self,
+        _index: u64,
+        _header: &RpcOptionalHeader,
+        accepted_transactions: &[RpcOptionalTransaction],
+    ) -> Vec<Tx> {
+        accepted_transactions
+            .iter()
+            .filter_map(|l1_tx| Tx::try_from_slice(l1_tx.payload.as_ref()?).ok())
+            .collect()
+    }
+}
 
+impl VmInterface for TestNodeVm {
     fn process_transaction<S: Store<StateSpace = StateSpace>>(
         &self,
         tx: &Self::Transaction,
@@ -34,30 +42,17 @@ impl VmInterface for TestNodeVm {
     fn post_process_batch<S: Store<StateSpace = StateSpace>>(&self, batch: &RuntimeBatch<S, Self>) {
         if !batch.was_canceled() {
             eprintln!(
-                ">> Processed batch with {} transactions and {} state changes",
+                ">> Post Processed batch with {} transactions and {} state changes",
                 batch.txs().len(),
                 batch.state_diffs().len()
             );
         }
     }
-}
 
-impl NodeVm for TestNodeVm {
-    fn pre_process_block(
-        &self,
-        index: u64,
-        _header: &RpcOptionalHeader,
-        accepted_transactions: &[RpcOptionalTransaction],
-    ) -> Vec<Tx> {
-        // Each accepted L1 tx becomes a deterministic L2 write.
-        // resource_id = block_index * 1000 + position_in_block
-        accepted_transactions
-            .iter()
-            .enumerate()
-            .map(|(i, _)| {
-                let resource_id = index as usize * 1000 + i;
-                Tx(resource_id, vec![Access::Write(resource_id)])
-            })
-            .collect()
-    }
+    type Transaction = Tx;
+    type TransactionEffects = ();
+    type ResourceId = usize;
+    type AccessMetadata = Access;
+    type BatchMetadata = ChainBlockMetadata;
+    type Error = ();
 }

--- a/node/vm/Cargo.toml
+++ b/node/vm/Cargo.toml
@@ -4,6 +4,8 @@ name              = "vprogs-node-vm"
 version.workspace = true
 
 [dependencies]
+vprogs-node-framework.workspace                          = true
+vprogs-node-l1-bridge.workspace                          = true
 vprogs-scheduling-scheduler.workspace                    = true
 vprogs-state-space.workspace                             = true
 vprogs-storage-types.workspace                           = true

--- a/node/vm/src/lib.rs
+++ b/node/vm/src/lib.rs
@@ -1,6 +1,6 @@
 use vprogs_node_framework::NodeVm;
 use vprogs_node_l1_bridge::{ChainBlockMetadata, RpcOptionalHeader, RpcOptionalTransaction};
-use vprogs_scheduling_scheduler::{AccessHandle, RuntimeBatch, VmInterface};
+use vprogs_scheduling_scheduler::{AccessHandle, VmInterface};
 use vprogs_state_space::StateSpace;
 use vprogs_storage_types::Store;
 use vprogs_transaction_runtime::TransactionRuntime;

--- a/node/vm/src/lib.rs
+++ b/node/vm/src/lib.rs
@@ -1,4 +1,6 @@
-use vprogs_scheduling_scheduler::{AccessHandle, VmInterface};
+use vprogs_node_framework::NodeVm;
+use vprogs_node_l1_bridge::{ChainBlockMetadata, RpcOptionalHeader, RpcOptionalTransaction};
+use vprogs_scheduling_scheduler::{AccessHandle, RuntimeBatch, VmInterface};
 use vprogs_state_space::StateSpace;
 use vprogs_storage_types::Store;
 use vprogs_transaction_runtime::TransactionRuntime;
@@ -28,6 +30,18 @@ impl VmInterface for VM {
     type TransactionEffects = TransactionEffects;
     type ResourceId = ObjectId;
     type AccessMetadata = ObjectAccess;
-    type BatchMetadata = ();
+    type BatchMetadata = ChainBlockMetadata;
     type Error = VmError;
+}
+
+/// Stub implementation — returns an empty transaction vec for now.
+impl NodeVm for VM {
+    fn pre_process_block(
+        &self,
+        _index: u64,
+        _header: &RpcOptionalHeader,
+        _accepted_transactions: &[RpcOptionalTransaction],
+    ) -> Vec<Transaction> {
+        vec![]
+    }
 }


### PR DESCRIPTION
This PR introduces the node-framework, a generic orchestration layer that connects the L1 bridge to the L2 scheduler, turning the separate subsystems into a cohesive node.

Previously the bridge and scheduler existed as independent components - the bridge emitted events and the scheduler processed transactions, but nothing tied them together. Any integration required the caller to manually poll bridge events, translate L1 blocks into L2 transactions, feed them to the scheduler in order, handle rollbacks, manage shutdown sequencing, and provide a thread-safe way to query scheduler state. This PR encapsulates all of that into a single Node type.

The core design challenge is block ordering: L1 blocks must be fed to the scheduler sequentially (the scheduler is index-ordered), but pre-processing each block (translating headers and accepted transactions into L2 transactions via NodeVm::pre_process_block) can be parallelized. The framework solves this with a Batch type backed by ArcSwapOption + AtomicAsyncLatch - blocks are dispatched to execution workers out of order, and the event loop awaits the next in-sequence batch before feeding it to the scheduler.

**Key changes:**

  - NodeVm trait - extends VmInterface<BatchMetadata = ChainBlockMetadata> with pre_process_block(index, header, accepted_transactions) -> Vec<Transaction>, called on execution worker threads
  - Node - starts the bridge, scheduler, and event loop on a dedicated thread; provides api() for external queries and shutdown() for clean teardown (with Drop safety)
  - NodeWorker - priority-based event loop (shutdown > batch prepared > API request > bridge event) using biased tokio::select!; handles ChainBlockAdded, Rollback, Finalized, and Fatal events
  - Batch - lock-free one-shot container for pre-processing results, coordinated via AtomicAsyncLatch; queued in a VecDeque and drained front-to-back to preserve ordering
  - NodeApi - cloneable handle that sends closures over a bounded mpsc channel to the worker thread, executing them against &mut Scheduler and returning results via oneshot; exposes last_committed, last_processed,
  last_pruned, pruning_threshold, cached_resource_count, and a generic with_scheduler
  - NodeConfig - wraps ExecutionConfig, StorageConfig, and L1BridgeConfig with node-level settings (API channel capacity)
  - VM implements NodeVm - stub pre_process_block returning an empty vec for now; sets BatchMetadata = ChainBlockMetadata
