### PR TITLE
Feat: Introduce ChainBlockMetadata in L1 bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,6 +5427,7 @@ name = "vprogs-node-l1-bridge"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "borsh",
  "crossbeam-queue",
  "futures",
  "kaspa-consensus-core",
@@ -5439,6 +5440,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "vprogs-core-macros",
+ "vprogs-core-types",
  "vprogs-node-test-suite",
  "workflow-core",
 ]

--- a/node/l1-bridge/Cargo.toml
+++ b/node/l1-bridge/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 
 [dependencies]
 arc-swap.workspace             = true
+borsh.workspace                = true
 crossbeam-queue.workspace      = true
 futures.workspace              = true
 kaspa-consensus-core.workspace = true
@@ -17,6 +18,7 @@ tap.workspace                  = true
 thiserror.workspace            = true
 tokio.workspace                = true
 vprogs-core-macros.workspace   = true
+vprogs-core-types.workspace    = true
 workflow-core.workspace        = true
 
 [dev-dependencies]

--- a/node/l1-bridge/src/bridge.rs
+++ b/node/l1-bridge/src/bridge.rs
@@ -37,16 +37,11 @@ impl L1Bridge {
             let shutdown = shutdown.clone();
 
             move || {
-                let runtime = Builder::new_current_thread()
+                Builder::new_current_thread()
                     .enable_all()
                     .build()
-                    .expect("failed to build tokio runtime");
-
-                runtime.block_on(async {
-                    if let Some(worker) = BridgeWorker::new(&config, queue, event_signal).await {
-                        worker.run(shutdown).await;
-                    }
-                });
+                    .expect("failed to build tokio runtime")
+                    .block_on(BridgeWorker::spawn(&config, queue, event_signal, shutdown));
             }
         });
 

--- a/node/l1-bridge/src/chain_block.rs
+++ b/node/l1-bridge/src/chain_block.rs
@@ -83,12 +83,14 @@ impl ChainBlock {
     }
 }
 
+/// Extracts the persistable checkpoint (index + metadata) from a chain block.
 impl From<ChainBlock> for Checkpoint<ChainBlockMetadata> {
     fn from(block: ChainBlock) -> Self {
         Self::new(block.index(), block.metadata())
     }
 }
 
+/// Reconstructs an unlinked chain block from a persisted checkpoint.
 impl From<Checkpoint<ChainBlockMetadata>> for ChainBlock {
     fn from(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
         Self::new(checkpoint.index(), *checkpoint.metadata())

--- a/node/l1-bridge/src/chain_block.rs
+++ b/node/l1-bridge/src/chain_block.rs
@@ -16,7 +16,7 @@ use crate::ChainBlockMetadata;
 pub struct ChainBlock {
     /// Sequential index relative to the bridge's starting point.
     index: u64,
-    /// Persistable metadata (hash, blue score).
+    /// Persistable metadata.
     metadata: ChainBlockMetadata,
     /// Link to the preceding block, or empty if this is the root.
     prev: ArcSwapOption<ChainBlockData>,
@@ -40,7 +40,7 @@ impl ChainBlock {
         self.index
     }
 
-    /// Returns the persistable metadata (hash, blue score).
+    /// Returns the persistable metadata.
     pub fn metadata(&self) -> ChainBlockMetadata {
         self.metadata
     }

--- a/node/l1-bridge/src/chain_block.rs
+++ b/node/l1-bridge/src/chain_block.rs
@@ -11,13 +11,11 @@ use vprogs_core_types::Checkpoint;
 
 use crate::ChainBlockMetadata;
 
-/// A block in the virtual chain, forming a doubly-linked list.
-#[smart_pointer]
+/// A block in the virtual chain — a [`Checkpoint`] with doubly-linked list pointers.
+#[smart_pointer(deref = checkpoint)]
 pub struct ChainBlock {
-    /// Sequential index relative to the bridge's starting point.
-    index: u64,
-    /// Persistable metadata.
-    metadata: ChainBlockMetadata,
+    /// Persistable state (index + metadata).
+    checkpoint: Checkpoint<ChainBlockMetadata>,
     /// Link to the preceding block, or empty if this is the root.
     prev: ArcSwapOption<ChainBlockData>,
     /// Link to the following block, or empty if this is the tip.
@@ -25,32 +23,25 @@ pub struct ChainBlock {
 }
 
 impl ChainBlock {
+    /// Returns the persistable checkpoint (index + metadata).
+    pub fn checkpoint(&self) -> &Checkpoint<ChainBlockMetadata> {
+        &self.checkpoint
+    }
+
     /// Creates a standalone block with no links.
-    pub fn new(index: u64, metadata: ChainBlockMetadata) -> Self {
+    pub fn new(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
         Self(Arc::new(ChainBlockData {
-            index,
-            metadata,
+            checkpoint,
             prev: ArcSwapOption::empty(),
             next: ArcSwapOption::empty(),
         }))
-    }
-
-    /// Returns the sequential index.
-    pub fn index(&self) -> u64 {
-        self.index
-    }
-
-    /// Returns the persistable metadata.
-    pub fn metadata(&self) -> ChainBlockMetadata {
-        self.metadata
     }
 
     /// Appends a new block after this one and links them in both directions.
     pub(crate) fn advance_tip(&self, metadata: ChainBlockMetadata) -> Self {
         // Create the new block with a back-link to self.
         Self(Arc::new(ChainBlockData {
-            index: self.index + 1,
-            metadata,
+            checkpoint: Checkpoint::new(self.index() + 1, metadata),
             prev: ArcSwapOption::new(Some(self.0.clone())),
             next: ArcSwapOption::empty(),
         }))
@@ -83,32 +74,15 @@ impl ChainBlock {
     }
 }
 
-/// Extracts the persistable checkpoint (index + metadata) from a chain block.
-impl From<ChainBlock> for Checkpoint<ChainBlockMetadata> {
-    fn from(block: ChainBlock) -> Self {
-        Self::new(block.index(), block.metadata())
-    }
-}
-
-/// Reconstructs an unlinked chain block from a persisted checkpoint.
-impl From<Checkpoint<ChainBlockMetadata>> for ChainBlock {
-    fn from(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
-        Self::new(checkpoint.index(), *checkpoint.metadata())
-    }
-}
-
 impl Default for ChainBlock {
     /// Returns a sentinel root (zero hash, index 0).
     fn default() -> Self {
-        Self::new(0, ChainBlockMetadata::default())
+        Self::new(Checkpoint::default())
     }
 }
 
 impl Debug for ChainBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChainBlock")
-            .field("index", &self.index)
-            .field("metadata", &self.metadata)
-            .finish()
+        f.debug_struct("ChainBlock").field("checkpoint", &self.checkpoint).finish()
     }
 }

--- a/node/l1-bridge/src/chain_block.rs
+++ b/node/l1-bridge/src/chain_block.rs
@@ -5,21 +5,19 @@ use std::{
 };
 
 use arc_swap::ArcSwapOption;
-use kaspa_hashes::ZERO_HASH;
 use tap::{Tap, TapOptional};
 use vprogs_core_macros::smart_pointer;
+use vprogs_core_types::Checkpoint;
 
-use crate::BlockHash;
+use crate::ChainBlockMetadata;
 
 /// A block in the virtual chain, forming a doubly-linked list.
 #[smart_pointer]
 pub struct ChainBlock {
-    /// L1 block hash.
-    hash: BlockHash,
     /// Sequential index relative to the bridge's starting point.
     index: u64,
-    /// Blue score from the L1 block header.
-    blue_score: u64,
+    /// Persistable metadata (hash, blue score).
+    metadata: ChainBlockMetadata,
     /// Link to the preceding block, or empty if this is the root.
     prev: ArcSwapOption<ChainBlockData>,
     /// Link to the following block, or empty if this is the tip.
@@ -28,19 +26,13 @@ pub struct ChainBlock {
 
 impl ChainBlock {
     /// Creates a standalone block with no links.
-    pub fn new(hash: BlockHash, index: u64, blue_score: u64) -> Self {
+    pub fn new(index: u64, metadata: ChainBlockMetadata) -> Self {
         Self(Arc::new(ChainBlockData {
-            hash,
             index,
-            blue_score,
+            metadata,
             prev: ArcSwapOption::empty(),
             next: ArcSwapOption::empty(),
         }))
-    }
-
-    /// Returns the block hash.
-    pub fn hash(&self) -> BlockHash {
-        self.hash
     }
 
     /// Returns the sequential index.
@@ -48,18 +40,17 @@ impl ChainBlock {
         self.index
     }
 
-    /// Returns the blue score from the L1 block header.
-    pub fn blue_score(&self) -> u64 {
-        self.blue_score
+    /// Returns the persistable metadata (hash, blue score).
+    pub fn metadata(&self) -> ChainBlockMetadata {
+        self.metadata
     }
 
     /// Appends a new block after this one and links them in both directions.
-    pub(crate) fn advance_tip(&self, hash: BlockHash, blue_score: u64) -> Self {
+    pub(crate) fn advance_tip(&self, metadata: ChainBlockMetadata) -> Self {
         // Create the new block with a back-link to self.
         Self(Arc::new(ChainBlockData {
-            hash,
             index: self.index + 1,
-            blue_score,
+            metadata,
             prev: ArcSwapOption::new(Some(self.0.clone())),
             next: ArcSwapOption::empty(),
         }))
@@ -92,19 +83,30 @@ impl ChainBlock {
     }
 }
 
+impl From<ChainBlock> for Checkpoint<ChainBlockMetadata> {
+    fn from(block: ChainBlock) -> Self {
+        Self::new(block.index(), block.metadata())
+    }
+}
+
+impl From<Checkpoint<ChainBlockMetadata>> for ChainBlock {
+    fn from(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
+        Self::new(checkpoint.index(), *checkpoint.metadata())
+    }
+}
+
 impl Default for ChainBlock {
     /// Returns a sentinel root (zero hash, index 0).
     fn default() -> Self {
-        Self::new(ZERO_HASH, 0, 0)
+        Self::new(0, ChainBlockMetadata::default())
     }
 }
 
 impl Debug for ChainBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChainBlock")
-            .field("hash", &self.hash)
             .field("index", &self.index)
-            .field("blue_score", &self.blue_score)
+            .field("metadata", &self.metadata)
             .finish()
     }
 }

--- a/node/l1-bridge/src/chain_block.rs
+++ b/node/l1-bridge/src/chain_block.rs
@@ -11,7 +11,7 @@ use vprogs_core_types::Checkpoint;
 
 use crate::ChainBlockMetadata;
 
-/// A block in the virtual chain — a [`Checkpoint`] with doubly-linked list pointers.
+/// A block in the virtual chain - a [`Checkpoint`] with doubly-linked list pointers.
 #[smart_pointer(deref = checkpoint)]
 pub struct ChainBlock {
     /// Persistable state (index + metadata).
@@ -23,11 +23,6 @@ pub struct ChainBlock {
 }
 
 impl ChainBlock {
-    /// Returns the persistable checkpoint (index + metadata).
-    pub fn checkpoint(&self) -> &Checkpoint<ChainBlockMetadata> {
-        &self.checkpoint
-    }
-
     /// Creates a standalone block with no links.
     pub fn new(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
         Self(Arc::new(ChainBlockData {
@@ -35,6 +30,11 @@ impl ChainBlock {
             prev: ArcSwapOption::empty(),
             next: ArcSwapOption::empty(),
         }))
+    }
+
+    /// Returns the persistable checkpoint (index + metadata).
+    pub fn checkpoint(&self) -> &Checkpoint<ChainBlockMetadata> {
+        &self.checkpoint
     }
 
     /// Appends a new block after this one and links them in both directions.

--- a/node/l1-bridge/src/chain_block_metadata.rs
+++ b/node/l1-bridge/src/chain_block_metadata.rs
@@ -5,8 +5,9 @@ use crate::BlockHash;
 /// Persistable metadata extracted from an L1 chain block.
 ///
 /// Contains the fields needed to reconstruct a [`ChainBlock`](crate::ChainBlock) on resume.
-/// Implements [`BatchMetadata`](vprogs_core_types::BatchMetadata) automatically via Borsh.
-#[derive(Clone, Copy, Debug, Default, BorshSerialize, BorshDeserialize)]
+/// Satisfies the [`BatchMetadata`](vprogs_core_types::BatchMetadata) blanket impl via its derived
+/// traits.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChainBlockMetadata {
     /// L1 block hash.
     hash: BlockHash,

--- a/node/l1-bridge/src/chain_block_metadata.rs
+++ b/node/l1-bridge/src/chain_block_metadata.rs
@@ -1,0 +1,32 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::BlockHash;
+
+/// Persistable metadata extracted from an L1 chain block.
+///
+/// Contains the fields needed to reconstruct a [`ChainBlock`](crate::ChainBlock) on resume.
+/// Implements [`BatchMetadata`](vprogs_core_types::BatchMetadata) automatically via Borsh.
+#[derive(Clone, Copy, Debug, Default, BorshSerialize, BorshDeserialize)]
+pub struct ChainBlockMetadata {
+    /// L1 block hash.
+    hash: BlockHash,
+    /// DAG blue score at this block's position.
+    blue_score: u64,
+}
+
+impl ChainBlockMetadata {
+    /// Creates metadata from a block hash and blue score.
+    pub fn new(hash: BlockHash, blue_score: u64) -> Self {
+        Self { hash, blue_score }
+    }
+
+    /// Returns the L1 block hash.
+    pub fn hash(&self) -> BlockHash {
+        self.hash
+    }
+
+    /// Returns the DAG blue score.
+    pub fn blue_score(&self) -> u64 {
+        self.blue_score
+    }
+}

--- a/node/l1-bridge/src/chain_block_metadata.rs
+++ b/node/l1-bridge/src/chain_block_metadata.rs
@@ -2,9 +2,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::BlockHash;
 
-/// Persistable metadata extracted from an L1 chain block.
+/// Relevant metadata extracted from an L1 chain block.
 ///
-/// Contains the fields needed to reconstruct a [`ChainBlock`](crate::ChainBlock) on resume.
 /// Satisfies the [`BatchMetadata`](vprogs_core_types::BatchMetadata) blanket impl via its derived
 /// traits.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]

--- a/node/l1-bridge/src/config.rs
+++ b/node/l1-bridge/src/config.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use crate::{ChainBlock, ConnectStrategy, NetworkId, NetworkType};
+use vprogs_core_types::Checkpoint;
+
+use crate::{ChainBlockMetadata, ConnectStrategy, NetworkId, NetworkType};
 
 /// Configuration for the L1 bridge.
 #[derive(Clone, Debug)]
@@ -15,9 +17,9 @@ pub struct L1BridgeConfig {
     pub connect_strategy: ConnectStrategy,
     /// Finalization boundary, or `None` to start from the L1 pruning point. When set together with
     /// `tip`, the bridge backfills the chain between them on startup.
-    pub root: Option<ChainBlock>,
+    pub root: Option<Checkpoint<ChainBlockMetadata>>,
     /// Last known tip, or `None` to start from the L1 pruning point.
-    pub tip: Option<ChainBlock>,
+    pub tip: Option<Checkpoint<ChainBlockMetadata>>,
     /// Reorg filter halving period. Observed reorg depths accumulate into a threshold that halves
     /// every period until it reaches zero. Set to `Duration::ZERO` to disable (default).
     pub reorg_filter_halving_period: Duration,
@@ -70,14 +72,14 @@ impl L1BridgeConfig {
     }
 
     /// Sets the finalization boundary to resume from.
-    pub fn with_root(mut self, block: Option<ChainBlock>) -> Self {
-        self.root = block;
+    pub fn with_root(mut self, checkpoint: Option<Checkpoint<ChainBlockMetadata>>) -> Self {
+        self.root = checkpoint;
         self
     }
 
     /// Sets the last known tip to resume from.
-    pub fn with_tip(mut self, block: Option<ChainBlock>) -> Self {
-        self.tip = block;
+    pub fn with_tip(mut self, checkpoint: Option<Checkpoint<ChainBlockMetadata>>) -> Self {
+        self.tip = checkpoint;
         self
     }
 

--- a/node/l1-bridge/src/event.rs
+++ b/node/l1-bridge/src/event.rs
@@ -1,7 +1,8 @@
 pub use kaspa_hashes::Hash;
 pub use kaspa_rpc_core::{RpcOptionalHeader, RpcOptionalTransaction};
+use vprogs_core_types::Checkpoint;
 
-use crate::ChainBlock;
+use crate::{ChainBlock, ChainBlockMetadata};
 
 /// Events emitted by the L1 bridge.
 #[derive(Clone, Debug)]
@@ -12,17 +13,17 @@ pub enum L1Event {
     Disconnected,
     /// A new chain block with its accepted transactions.
     ChainBlockAdded {
-        /// Sequential index relative to the bridge's starting point.
-        index: u64,
+        /// Checkpoint (index + metadata) for this block.
+        checkpoint: Checkpoint<ChainBlockMetadata>,
         /// Block header.
         header: Box<RpcOptionalHeader>,
         /// Transactions from this block's mergeset that became confirmed.
         accepted_transactions: Vec<RpcOptionalTransaction>,
     },
-    /// Blocks after this index have been removed due to a reorg.
+    /// Blocks after this checkpoint have been removed due to a reorg.
     Rollback {
-        /// New tip index after the rollback.
-        index: u64,
+        /// Checkpoint of the new tip after the rollback.
+        checkpoint: Checkpoint<ChainBlockMetadata>,
         /// Blue score difference between old and new tip.
         blue_score_depth: u64,
     },

--- a/node/l1-bridge/src/event.rs
+++ b/node/l1-bridge/src/event.rs
@@ -2,7 +2,7 @@ pub use kaspa_hashes::Hash;
 pub use kaspa_rpc_core::{RpcOptionalHeader, RpcOptionalTransaction};
 use vprogs_core_types::Checkpoint;
 
-use crate::{ChainBlock, ChainBlockMetadata};
+use crate::ChainBlockMetadata;
 
 /// Events emitted by the L1 bridge.
 #[derive(Clone, Debug)]
@@ -27,8 +27,8 @@ pub enum L1Event {
         /// Blue score difference between old and new tip.
         blue_score_depth: u64,
     },
-    /// Blocks up to this block are finalized and can be pruned.
-    Finalized(ChainBlock),
+    /// Blocks up to this checkpoint are finalized and can be pruned.
+    Finalized(Checkpoint<ChainBlockMetadata>),
     /// The bridge encountered a fatal error and stopped.
     Fatal {
         /// What went wrong.

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -26,8 +26,8 @@
 //!         Some(L1Event::Rollback { checkpoint, blue_score_depth }) => {
 //!             println!("rollback to {} (depth: {blue_score_depth})", checkpoint.index());
 //!         }
-//!         Some(L1Event::Finalized(block)) => {
-//!             println!("finalized up to index {}", block.index());
+//!         Some(L1Event::Finalized(checkpoint)) => {
+//!             println!("finalized up to index {}", checkpoint.index());
 //!         }
 //!         Some(L1Event::Disconnected) => println!("disconnected"),
 //!         Some(L1Event::Fatal { reason }) => {
@@ -61,7 +61,6 @@ mod virtual_chain;
 mod worker;
 
 pub use bridge::L1Bridge;
-pub use chain_block::ChainBlock;
 pub use chain_block_metadata::ChainBlockMetadata;
 pub use config::L1BridgeConfig;
 pub use event::{Hash as BlockHash, L1Event, RpcOptionalHeader, RpcOptionalTransaction};

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -20,11 +20,11 @@
 //! loop {
 //!     match bridge.pop() {
 //!         Some(L1Event::Connected) => println!("connected"),
-//!         Some(L1Event::ChainBlockAdded { index, .. }) => {
-//!             println!("block {index}");
+//!         Some(L1Event::ChainBlockAdded { checkpoint, .. }) => {
+//!             println!("block {}", checkpoint.index());
 //!         }
-//!         Some(L1Event::Rollback { index, blue_score_depth }) => {
-//!             println!("rollback to {index} (depth: {blue_score_depth})");
+//!         Some(L1Event::Rollback { checkpoint, blue_score_depth }) => {
+//!             println!("rollback to {} (depth: {blue_score_depth})", checkpoint.index());
 //!         }
 //!         Some(L1Event::Finalized(block)) => {
 //!             println!("finalized up to index {}", block.index());
@@ -52,6 +52,7 @@
 
 mod bridge;
 mod chain_block;
+mod chain_block_metadata;
 mod config;
 mod error;
 mod event;
@@ -61,6 +62,7 @@ mod worker;
 
 pub use bridge::L1Bridge;
 pub use chain_block::ChainBlock;
+pub use chain_block_metadata::ChainBlockMetadata;
 pub use config::L1BridgeConfig;
 pub use event::{Hash as BlockHash, L1Event, RpcOptionalHeader, RpcOptionalTransaction};
 pub use kaspa_consensus_core::network::{NetworkId, NetworkType};

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -67,4 +67,3 @@ pub use config::L1BridgeConfig;
 pub use event::{Hash as BlockHash, L1Event, RpcOptionalHeader, RpcOptionalTransaction};
 pub use kaspa_consensus_core::network::{NetworkId, NetworkType};
 pub use kaspa_wrpc_client::prelude::ConnectStrategy;
-pub use vprogs_core_types::Checkpoint;

--- a/node/l1-bridge/src/lib.rs
+++ b/node/l1-bridge/src/lib.rs
@@ -67,3 +67,4 @@ pub use config::L1BridgeConfig;
 pub use event::{Hash as BlockHash, L1Event, RpcOptionalHeader, RpcOptionalTransaction};
 pub use kaspa_consensus_core::network::{NetworkId, NetworkType};
 pub use kaspa_wrpc_client::prelude::ConnectStrategy;
+pub use vprogs_core_types::Checkpoint;

--- a/node/l1-bridge/src/virtual_chain.rs
+++ b/node/l1-bridge/src/virtual_chain.rs
@@ -37,7 +37,7 @@ impl VirtualChain {
         metadata: ChainBlockMetadata,
     ) -> Checkpoint<ChainBlockMetadata> {
         self.tip = self.tip.advance_tip(metadata);
-        self.tip.clone().into()
+        self.tip.checkpoint().clone()
     }
 
     /// Rolls back `num_blocks` from the tip and returns a checkpoint for the new tip along with
@@ -60,7 +60,7 @@ impl VirtualChain {
         }
         let blue_score_depth = old_blue_score.saturating_sub(self.tip.metadata().blue_score());
 
-        Ok((self.tip.clone().into(), blue_score_depth))
+        Ok((self.tip.checkpoint().clone(), blue_score_depth))
     }
 
     /// Advances the root forward to the block matching `hash`, unlinking all nodes it passes.

--- a/node/l1-bridge/src/virtual_chain.rs
+++ b/node/l1-bridge/src/virtual_chain.rs
@@ -16,22 +16,23 @@ pub(crate) struct VirtualChain {
 }
 
 impl VirtualChain {
-    /// Creates a new chain where both root and tip point to the given block.
-    pub(crate) fn new(root: ChainBlock) -> Self {
+    /// Creates a new chain where both root and tip point to the given checkpoint.
+    pub(crate) fn new(checkpoint: Checkpoint<ChainBlockMetadata>) -> Self {
+        let root = ChainBlock::new(checkpoint);
         Self { root: root.clone(), tip: root }
     }
 
-    /// Returns the current tip.
-    pub(crate) fn tip(&self) -> ChainBlock {
-        self.tip.clone()
+    /// Returns the checkpoint for the current tip.
+    pub(crate) fn tip(&self) -> Checkpoint<ChainBlockMetadata> {
+        self.tip.checkpoint().clone()
     }
 
-    /// Returns the current root.
-    pub(crate) fn root(&self) -> ChainBlock {
-        self.root.clone()
+    /// Returns the checkpoint for the current root.
+    pub(crate) fn root(&self) -> Checkpoint<ChainBlockMetadata> {
+        self.root.checkpoint().clone()
     }
 
-    /// Appends a block at the tip and returns a checkpoint for the new tip.
+    /// Appends a checkpoint at the tip and returns it.
     pub(crate) fn advance_tip(
         &mut self,
         metadata: ChainBlockMetadata,
@@ -40,22 +41,22 @@ impl VirtualChain {
         self.tip.checkpoint().clone()
     }
 
-    /// Rolls back `num_blocks` from the tip and returns a checkpoint for the new tip along with
-    /// the blue score depth (difference between old and new tip). Returns an error if the rollback
+    /// Rolls back `num_checkpoints` from the tip and returns the new tip checkpoint along with the
+    /// blue score depth (difference between old and new tip). Returns an error if the rollback
     /// would go past the root.
     pub(crate) fn rollback(
         &mut self,
-        num_blocks: u64,
+        num_checkpoints: u64,
     ) -> Result<(Checkpoint<ChainBlockMetadata>, u64)> {
         // Ensure we don't roll back past the finalization boundary.
-        let target_index = self.tip.index().saturating_sub(num_blocks);
+        let target_index = self.tip.index().saturating_sub(num_checkpoints);
         if target_index < self.root.index() {
             return Err(Error::RollbackPastRoot { target_index, root_index: self.root.index() });
         }
 
-        // Calculate reorg_depth and walk backwards, unlinking each block from its predecessor.
+        // Calculate reorg depth and walk backwards, unlinking each node from its predecessor.
         let old_blue_score = self.tip.metadata().blue_score();
-        for _ in 0..num_blocks {
+        for _ in 0..num_checkpoints {
             self.tip = self.tip.rollback_tip();
         }
         let blue_score_depth = old_blue_score.saturating_sub(self.tip.metadata().blue_score());
@@ -63,10 +64,13 @@ impl VirtualChain {
         Ok((self.tip.checkpoint().clone(), blue_score_depth))
     }
 
-    /// Advances the root forward to the block matching `hash`, unlinking all nodes it passes.
-    /// Returns the new root, `None` if already there, or an error if the hash is not found (which
-    /// destroys the chain — fatal).
-    pub(crate) fn advance_root(&mut self, hash: &BlockHash) -> Result<Option<ChainBlock>> {
+    /// Advances the root forward to the checkpoint matching `hash`, unlinking all nodes it passes.
+    /// Returns the new root checkpoint, `None` if already there, or an error if the hash is not
+    /// found (which destroys the chain - fatal).
+    pub(crate) fn advance_root(
+        &mut self,
+        hash: &BlockHash,
+    ) -> Result<Option<Checkpoint<ChainBlockMetadata>>> {
         // Already at this pruning point — nothing to do.
         if self.root.metadata().hash() == *hash {
             return Ok(None);
@@ -76,8 +80,8 @@ impl VirtualChain {
         let mut current = self.root.advance_root();
         while let Some(block) = current {
             if block.metadata().hash() == *hash {
-                self.root = block.clone();
-                return Ok(Some(block));
+                self.root = block;
+                return Ok(Some(self.root.checkpoint().clone()));
             }
             current = block.advance_root();
         }
@@ -88,7 +92,7 @@ impl VirtualChain {
 }
 
 impl Drop for VirtualChain {
-    /// Walks from root to tip, breaking Arc cycles between adjacent nodes.
+    /// Walks from root to tip, breaking Arc cycles between adjacent chain nodes.
     fn drop(&mut self) {
         let mut current = self.root.advance_root();
         while let Some(block) = current {

--- a/node/l1-bridge/src/virtual_chain.rs
+++ b/node/l1-bridge/src/virtual_chain.rs
@@ -53,7 +53,7 @@ impl VirtualChain {
             return Err(Error::RollbackPastRoot { target_index, root_index: self.root.index() });
         }
 
-        // Walk backwards, unlinking each block from its predecessor.
+        // Calculate reorg_depth and walk backwards, unlinking each block from its predecessor.
         let old_blue_score = self.tip.metadata().blue_score();
         for _ in 0..num_blocks {
             self.tip = self.tip.rollback_tip();

--- a/node/l1-bridge/src/virtual_chain.rs
+++ b/node/l1-bridge/src/virtual_chain.rs
@@ -1,5 +1,7 @@
+use vprogs_core_types::Checkpoint;
+
 use crate::{
-    BlockHash,
+    BlockHash, ChainBlockMetadata,
     chain_block::ChainBlock,
     error::{Error, Result},
 };
@@ -29,30 +31,36 @@ impl VirtualChain {
         self.root.clone()
     }
 
-    /// Appends a block at the tip and returns its index.
-    pub(crate) fn advance_tip(&mut self, hash: BlockHash, blue_score: u64) -> u64 {
-        self.tip = self.tip.advance_tip(hash, blue_score);
-        self.tip.index()
+    /// Appends a block at the tip and returns a checkpoint for the new tip.
+    pub(crate) fn advance_tip(
+        &mut self,
+        metadata: ChainBlockMetadata,
+    ) -> Checkpoint<ChainBlockMetadata> {
+        self.tip = self.tip.advance_tip(metadata);
+        self.tip.clone().into()
     }
 
-    /// Rolls back `num_blocks` from the tip and returns `(new_tip_index, blue_score_depth)`.
-    /// The blue score depth is the difference between the old and new tip blue scores. Returns an
-    /// error if the rollback would go past the root.
-    pub(crate) fn rollback(&mut self, num_blocks: u64) -> Result<(u64, u64)> {
+    /// Rolls back `num_blocks` from the tip and returns a checkpoint for the new tip along with
+    /// the blue score depth (difference between old and new tip). Returns an error if the rollback
+    /// would go past the root.
+    pub(crate) fn rollback(
+        &mut self,
+        num_blocks: u64,
+    ) -> Result<(Checkpoint<ChainBlockMetadata>, u64)> {
         // Ensure we don't roll back past the finalization boundary.
         let target_index = self.tip.index().saturating_sub(num_blocks);
         if target_index < self.root.index() {
             return Err(Error::RollbackPastRoot { target_index, root_index: self.root.index() });
         }
 
-        // Calculate reorg_depth and walk backwards, unlinking each block from its predecessor.
-        let old_blue_score = self.tip.blue_score();
+        // Walk backwards, unlinking each block from its predecessor.
+        let old_blue_score = self.tip.metadata().blue_score();
         for _ in 0..num_blocks {
             self.tip = self.tip.rollback_tip();
         }
-        let blue_score_depth = old_blue_score.saturating_sub(self.tip.blue_score());
+        let blue_score_depth = old_blue_score.saturating_sub(self.tip.metadata().blue_score());
 
-        Ok((self.tip.index(), blue_score_depth))
+        Ok((self.tip.clone().into(), blue_score_depth))
     }
 
     /// Advances the root forward to the block matching `hash`, unlinking all nodes it passes.
@@ -60,14 +68,14 @@ impl VirtualChain {
     /// destroys the chain — fatal).
     pub(crate) fn advance_root(&mut self, hash: &BlockHash) -> Result<Option<ChainBlock>> {
         // Already at this pruning point — nothing to do.
-        if self.root.hash() == *hash {
+        if self.root.metadata().hash() == *hash {
             return Ok(None);
         }
 
         // Walk forward from root, unlinking each node until we find the target.
         let mut current = self.root.advance_root();
         while let Some(block) = current {
-            if block.hash() == *hash {
+            if block.metadata().hash() == *hash {
                 self.root = block.clone();
                 return Ok(Some(block));
             }

--- a/node/l1-bridge/src/worker.rs
+++ b/node/l1-bridge/src/worker.rs
@@ -10,10 +10,11 @@ use kaspa_rpc_core::{
 };
 use kaspa_wrpc_client::prelude::*;
 use tokio::sync::Notify;
+use vprogs_core_types::Checkpoint;
 use workflow_core::channel::{Channel, MultiplexerChannel};
 
 use crate::{
-    ChainBlock, ChainBlockMetadata, L1BridgeConfig, L1Event,
+    ChainBlockMetadata, L1BridgeConfig, L1Event,
     error::{Error, Result},
     reorg_filter::ReorgFilter,
     virtual_chain::VirtualChain,
@@ -38,9 +39,9 @@ pub(crate) struct BridgeWorker {
     rpc_ctl_channel: MultiplexerChannel<RpcState>,
     /// Set to `true` on fatal errors to break out of the event loop.
     fatal: bool,
-    /// When resuming with both root and tip set, holds the tip block until the chain between root
-    /// and tip is backfilled on first connect.
-    backfill_target: Option<ChainBlock>,
+    /// When resuming with both root and tip set, holds the tip checkpoint until the chain between
+    /// root and tip is backfilled on first connect.
+    backfill_target: Option<Checkpoint<ChainBlockMetadata>>,
     /// Filters shallow reorgs based on accumulated depth.
     reorg_filter: ReorgFilter,
 }
@@ -56,8 +57,8 @@ impl BridgeWorker {
         shutdown: Arc<Notify>,
     ) {
         // Prefer root, fall back to tip, or default to a sentinel at index 0.
-        let root = config.root.clone().or(config.tip.clone()).unwrap_or_default();
-        let virtual_chain = VirtualChain::new(root);
+        let root_checkpoint = config.root.clone().or(config.tip.clone()).unwrap_or_default();
+        let virtual_chain = VirtualChain::new(root_checkpoint);
 
         // If both root and tip are provided and differ, we need to backfill the chain between them
         // on first connect (lightweight, non-verbose sync).
@@ -255,9 +256,9 @@ impl BridgeWorker {
         Ok(())
     }
 
-    /// Backfills the linked list between root and `target`. Only runs once on first connect when
-    /// resuming with a saved root/tip pair.
-    async fn backfill_chain(&mut self, target: &ChainBlock) -> Result<()> {
+    /// Backfills the chain between root and `target`. Only runs once on first connect when resuming
+    /// with a saved root/tip pair.
+    async fn backfill_chain(&mut self, target: &Checkpoint<ChainBlockMetadata>) -> Result<()> {
         let start = self.virtual_chain.root();
 
         log::info!(

--- a/node/l1-bridge/src/worker.rs
+++ b/node/l1-bridge/src/worker.rs
@@ -124,7 +124,7 @@ impl BridgeWorker {
     }
 
     /// Priority-based event loop: shutdown > RPC state > chain notifications.
-    async fn run(&mut self) {
+    async fn run(mut self) {
         loop {
             if self.fatal {
                 log::error!("L1 bridge: stopping due to fatal error");

--- a/node/l1-bridge/src/worker.rs
+++ b/node/l1-bridge/src/worker.rs
@@ -13,7 +13,7 @@ use tokio::sync::Notify;
 use workflow_core::channel::{Channel, MultiplexerChannel};
 
 use crate::{
-    ChainBlock, L1BridgeConfig, L1Event,
+    ChainBlock, ChainBlockMetadata, L1BridgeConfig, L1Event,
     error::{Error, Result},
     reorg_filter::ReorgFilter,
     virtual_chain::VirtualChain,
@@ -30,6 +30,8 @@ pub(crate) struct BridgeWorker {
     queue: Arc<SegQueue<L1Event>>,
     /// Wakes the consumer after pushing an event.
     event_signal: Arc<Notify>,
+    /// Signals the worker to shut down.
+    shutdown: Arc<Notify>,
     /// Receives L1 chain notifications (VCC, pruning point).
     notification_channel: Channel<Notification>,
     /// Receives RPC connection state changes.
@@ -44,13 +46,15 @@ pub(crate) struct BridgeWorker {
 }
 
 impl BridgeWorker {
-    /// Connects to the L1 node and returns a ready worker, or `None` if connection fails (a `Fatal`
-    /// event is pushed in that case).
-    pub(crate) async fn new(
+    /// Connects to the L1 node and runs the event loop until shutdown or a fatal error.
+    ///
+    /// If connection fails, pushes a [`L1Event::Fatal`] and returns immediately.
+    pub(crate) async fn spawn(
         config: &L1BridgeConfig,
         queue: Arc<SegQueue<L1Event>>,
         event_signal: Arc<Notify>,
-    ) -> Option<Self> {
+        shutdown: Arc<Notify>,
+    ) {
         // Prefer root, fall back to tip, or default to a sentinel at index 0.
         let root = config.root.clone().or(config.tip.clone()).unwrap_or_default();
         let virtual_chain = VirtualChain::new(root);
@@ -58,7 +62,9 @@ impl BridgeWorker {
         // If both root and tip are provided and differ, we need to backfill the chain between them
         // on first connect (lightweight, non-verbose sync).
         let backfill_target = match (&config.root, &config.tip) {
-            (Some(root), Some(tip)) if root.hash() != tip.hash() => Some(tip.clone()),
+            (Some(root), Some(tip)) if root.metadata().hash() != tip.metadata().hash() => {
+                Some(tip.clone())
+            }
             _ => None,
         };
 
@@ -77,7 +83,7 @@ impl BridgeWorker {
                 log::error!("L1 bridge: {}", reason);
                 queue.push(L1Event::Fatal { reason });
                 event_signal.notify_one();
-                return None;
+                return;
             }
         };
 
@@ -98,24 +104,27 @@ impl BridgeWorker {
             log::error!("L1 bridge: {}", reason);
             queue.push(L1Event::Fatal { reason });
             event_signal.notify_one();
-            return None;
+            return;
         }
 
-        Some(Self {
+        Self {
             client,
             virtual_chain,
             queue,
             event_signal,
+            shutdown,
             notification_channel: Channel::unbounded(),
             rpc_ctl_channel,
             fatal: false,
             backfill_target,
             reorg_filter: ReorgFilter::new(config.reorg_filter_halving_period),
-        })
+        }
+        .run()
+        .await;
     }
 
     /// Priority-based event loop: shutdown > RPC state > chain notifications.
-    pub(crate) async fn run(mut self, shutdown: Arc<Notify>) {
+    async fn run(&mut self) {
         loop {
             if self.fatal {
                 log::error!("L1 bridge: stopping due to fatal error");
@@ -124,7 +133,7 @@ impl BridgeWorker {
 
             // Priority: shutdown > connection state > chain notifications.
             select_biased! {
-                _ = shutdown.notified().fuse() => {
+                _ = self.shutdown.notified().fuse() => {
                     log::info!("L1 bridge shutdown requested");
                     break;
                 }
@@ -258,17 +267,19 @@ impl BridgeWorker {
         );
 
         // Fetch with Low verbosity — sufficient for hash and blue_score needed for chain blocks.
-        let response =
-            self.client.get_virtual_chain_from_block_v2(start.hash(), Some(Low), None).await?;
+        let response = self
+            .client
+            .get_virtual_chain_from_block_v2(start.metadata().hash(), Some(Low), None)
+            .await?;
 
         // Walk the chain block accepted transactions to get both hash and blue_score.
-        let target_hash = target.hash();
+        let target_hash = target.metadata().hash();
         let mut found = false;
 
         for chain_block in response.chain_block_accepted_transactions.iter() {
             let hash = chain_block.chain_block_header.hash.unwrap_or_default();
             let blue_score = chain_block.chain_block_header.blue_score.unwrap_or(0);
-            self.virtual_chain.advance_tip(hash, blue_score);
+            self.virtual_chain.advance_tip(ChainBlockMetadata::new(hash, blue_score));
             if hash == target_hash {
                 found = true;
                 break;
@@ -292,7 +303,7 @@ impl BridgeWorker {
         let start_hash = if tip.index() == 0 {
             self.client.get_block_dag_info().await?.pruning_point_hash
         } else {
-            tip.hash()
+            tip.metadata().hash()
         };
 
         // Fetch with High verbosity to get full headers and accepted transactions.
@@ -319,9 +330,10 @@ impl BridgeWorker {
                 .chain_block_header
                 .blue_score
                 .expect("blue_score missing despite High verbosity");
-            let index = self.virtual_chain.advance_tip(hash, blue_score);
+            let metadata = ChainBlockMetadata::new(hash, blue_score);
+            let checkpoint = self.virtual_chain.advance_tip(metadata);
             self.push_event(L1Event::ChainBlockAdded {
-                index,
+                checkpoint,
                 header: Box::new(chain_block.chain_block_header.clone()),
                 accepted_transactions: chain_block.accepted_transactions.clone(),
             });
@@ -333,18 +345,18 @@ impl BridgeWorker {
     /// Rolls back the virtual chain, updates the reorg filter, and emits a `Rollback` event.
     fn handle_reorg(&mut self, response: &GetVirtualChainFromBlockV2Response) -> Result<()> {
         let num_removed = response.removed_chain_block_hashes.len() as u64;
-        let (rollback_index, blue_score_depth) = self.virtual_chain.rollback(num_removed)?;
+        let (checkpoint, blue_score_depth) = self.virtual_chain.rollback(num_removed)?;
         self.reorg_filter.record(blue_score_depth);
 
         log::info!(
             "L1 bridge: reorg detected, {} blocks removed, rolling back to index {} \
              (blue score depth: {}, filter threshold: {:?})",
             num_removed,
-            rollback_index,
+            checkpoint.index(),
             blue_score_depth,
             self.reorg_filter.threshold(),
         );
-        self.push_event(L1Event::Rollback { index: rollback_index, blue_score_depth });
+        self.push_event(L1Event::Rollback { checkpoint, blue_score_depth });
         Ok(())
     }
 

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use vprogs_node_l1_bridge::{
-    ChainBlock, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event, NetworkType, RpcOptionalHeader,
-    RpcOptionalTransaction,
+    ChainBlock, ChainBlockMetadata, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
+    NetworkType, RpcOptionalHeader, RpcOptionalTransaction,
 };
 use vprogs_node_test_suite::{L1BridgeExt, L1Node};
 
@@ -63,8 +63,8 @@ async fn test_bridge_block_contains_transactions() {
 
     assert_eq!(events.len(), 1);
     let (index, header, accepted_transactions) = match &events[0] {
-        L1Event::ChainBlockAdded { index, header, accepted_transactions } => {
-            (*index, header, accepted_transactions)
+        L1Event::ChainBlockAdded { checkpoint, header, accepted_transactions } => {
+            (checkpoint.index(), header, accepted_transactions)
         }
         other => panic!("expected ChainBlockAdded, got {:?}", other),
     };
@@ -93,7 +93,7 @@ async fn test_bridge_syncs_from_specific_block() {
         .with_url(node.wrpc_borsh_url())
         .with_network_type(NetworkType::Simnet)
         .with_connect_strategy(ConnectStrategy::Fallback)
-        .with_tip(Some(ChainBlock::new(start_from, 3, 0)));
+        .with_tip(Some(ChainBlock::new(3, ChainBlockMetadata::new(start_from, 0))));
 
     let bridge = L1Bridge::new(config);
 
@@ -152,7 +152,8 @@ async fn test_bridge_catches_up_after_reconnection() {
 
     // Save the last processed position as a checkpoint.
     let (last_index, last_header, _) = &blocks[2];
-    let checkpoint = ChainBlock::new(last_header.hash.unwrap(), *last_index, 0);
+    let checkpoint =
+        ChainBlock::new(*last_index, ChainBlockMetadata::new(last_header.hash.unwrap(), 0));
     assert_eq!(*last_index, 3);
 
     // Phase 2: Shutdown the bridge, mine blocks while it's down.
@@ -183,8 +184,8 @@ async fn test_bridge_catches_up_after_reconnection() {
     // Indices continue from the checkpoint: 4, 5, 6, 7, 8.
     for (i, event) in events[1..6].iter().enumerate() {
         match event {
-            L1Event::ChainBlockAdded { index, header, .. } => {
-                assert_eq!(*index, (i + 4) as u64);
+            L1Event::ChainBlockAdded { checkpoint, header, .. } => {
+                assert_eq!(checkpoint.index(), (i + 4) as u64);
                 assert_eq!(header.hash, Some(missed_hashes[i]));
             }
             other => panic!("expected ChainBlockAdded at position {}, got {:?}", i + 1, other),
@@ -236,7 +237,9 @@ async fn test_bridge_receives_reorg_events() {
         let blocks_after_rollback: Vec<_> = events[pos + 1..]
             .iter()
             .filter_map(|e| match e {
-                L1Event::ChainBlockAdded { index, header, .. } => Some((*index, header.hash)),
+                L1Event::ChainBlockAdded { checkpoint, header, .. } => {
+                    Some((checkpoint.index(), header.hash))
+                }
                 _ => None,
             })
             .collect();
@@ -346,7 +349,7 @@ async fn test_reorg_filter_causes_lag() {
         events
             .iter()
             .filter_map(|e| match e {
-                L1Event::ChainBlockAdded { index, .. } => Some(*index),
+                L1Event::ChainBlockAdded { checkpoint, .. } => Some(checkpoint.index()),
                 _ => None,
             })
             .max()
@@ -404,8 +407,8 @@ fn unwrap_chain_blocks(
     events
         .into_iter()
         .map(|e| match e {
-            L1Event::ChainBlockAdded { index, header, accepted_transactions } => {
-                (index, header, accepted_transactions)
+            L1Event::ChainBlockAdded { checkpoint, header, accepted_transactions } => {
+                (checkpoint.index(), header, accepted_transactions)
             }
             other => panic!("expected ChainBlockAdded, got {:?}", other),
         })

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
+use vprogs_core_types::Checkpoint;
 use vprogs_node_l1_bridge::{
-    ChainBlock, ChainBlockMetadata, Checkpoint, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
+    ChainBlock, ChainBlockMetadata, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
     NetworkType, RpcOptionalHeader, RpcOptionalTransaction,
 };
 use vprogs_node_test_suite::{L1BridgeExt, L1Node};

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use vprogs_node_l1_bridge::{
-    ChainBlock, ChainBlockMetadata, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
+    ChainBlock, ChainBlockMetadata, Checkpoint, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
     NetworkType, RpcOptionalHeader, RpcOptionalTransaction,
 };
 use vprogs_node_test_suite::{L1BridgeExt, L1Node};
@@ -93,7 +93,10 @@ async fn test_bridge_syncs_from_specific_block() {
         .with_url(node.wrpc_borsh_url())
         .with_network_type(NetworkType::Simnet)
         .with_connect_strategy(ConnectStrategy::Fallback)
-        .with_tip(Some(ChainBlock::new(3, ChainBlockMetadata::new(start_from, 0))));
+        .with_tip(Some(ChainBlock::new(Checkpoint::new(
+            3,
+            ChainBlockMetadata::new(start_from, 0),
+        ))));
 
     let bridge = L1Bridge::new(config);
 
@@ -152,8 +155,10 @@ async fn test_bridge_catches_up_after_reconnection() {
 
     // Save the last processed position as a checkpoint.
     let (last_index, last_header, _) = &blocks[2];
-    let checkpoint =
-        ChainBlock::new(*last_index, ChainBlockMetadata::new(last_header.hash.unwrap(), 0));
+    let checkpoint = ChainBlock::new(Checkpoint::new(
+        *last_index,
+        ChainBlockMetadata::new(last_header.hash.unwrap(), 0),
+    ));
     assert_eq!(*last_index, 3);
 
     // Phase 2: Shutdown the bridge, mine blocks while it's down.

--- a/node/l1-bridge/tests/integration.rs
+++ b/node/l1-bridge/tests/integration.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use vprogs_core_types::Checkpoint;
 use vprogs_node_l1_bridge::{
-    ChainBlock, ChainBlockMetadata, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event,
-    NetworkType, RpcOptionalHeader, RpcOptionalTransaction,
+    ChainBlockMetadata, ConnectStrategy, L1Bridge, L1BridgeConfig, L1Event, NetworkType,
+    RpcOptionalHeader, RpcOptionalTransaction,
 };
 use vprogs_node_test_suite::{L1BridgeExt, L1Node};
 
@@ -94,10 +94,7 @@ async fn test_bridge_syncs_from_specific_block() {
         .with_url(node.wrpc_borsh_url())
         .with_network_type(NetworkType::Simnet)
         .with_connect_strategy(ConnectStrategy::Fallback)
-        .with_tip(Some(ChainBlock::new(Checkpoint::new(
-            3,
-            ChainBlockMetadata::new(start_from, 0),
-        ))));
+        .with_tip(Some(Checkpoint::new(3, ChainBlockMetadata::new(start_from, 0))));
 
     let bridge = L1Bridge::new(config);
 
@@ -156,10 +153,8 @@ async fn test_bridge_catches_up_after_reconnection() {
 
     // Save the last processed position as a checkpoint.
     let (last_index, last_header, _) = &blocks[2];
-    let checkpoint = ChainBlock::new(Checkpoint::new(
-        *last_index,
-        ChainBlockMetadata::new(last_header.hash.unwrap(), 0),
-    ));
+    let checkpoint =
+        Checkpoint::new(*last_index, ChainBlockMetadata::new(last_header.hash.unwrap(), 0));
     assert_eq!(*last_index, 3);
 
     // Phase 2: Shutdown the bridge, mine blocks while it's down.
@@ -387,7 +382,7 @@ async fn test_reorg_filter_causes_lag() {
 /// Starts an L1 node and a connected bridge, waiting for the `Connected` event.
 async fn setup_node_with_bridge(
     strategy: ConnectStrategy,
-    tip: Option<ChainBlock>,
+    tip: Option<Checkpoint<ChainBlockMetadata>>,
 ) -> (L1Node, L1Bridge) {
     let node = L1Node::new().await;
 

--- a/node/test-suite/src/lib.rs
+++ b/node/test-suite/src/lib.rs
@@ -30,7 +30,7 @@
 //! node.mine_blocks(5).await;
 //! bridge
 //!     .wait_for(Duration::from_secs(10), |e| {
-//!         matches!(e, L1Event::ChainBlockAdded { index: 5, .. })
+//!         matches!(e, L1Event::ChainBlockAdded { checkpoint, .. } if checkpoint.index() == 5)
 //!     })
 //!     .await;
 //!


### PR DESCRIPTION
This PR introduces ChainBlockMetadata and updates the L1 bridge to use Checkpoint<ChainBlockMetadata> in its public API, aligning bridge events with the scheduler's checkpoint model.

Previously ChainBlock stored hash and blue_score as loose fields, and L1Event::ChainBlockAdded / L1Event::Rollback carried a raw index: u64. This meant the bridge spoke in flat integers while the scheduler (after the BatchMetadata PR) speaks in Checkpoint<M> - any consumer bridging the two had to manually wrap and unwrap.

**Key changes:**

  - ChainBlockMetadata - new Borsh-serializable struct bundling the L1 block hash and blue score; satisfies BatchMetadata automatically via the blanket impl
  - ChainBlock made private - now a crate-internal linked-list node that derefs to Checkpoint<ChainBlockMetadata> via #[smart_pointer(deref = checkpoint)]; no longer part of the public API
  - ChainBlock refactored - replaces the separate hash and blue_score fields with a single checkpoint: Checkpoint<ChainBlockMetadata>; constructor changes from new(hash, index, blue_score) to
  new(Checkpoint<ChainBlockMetadata>)
  - L1Event updated - ChainBlockAdded and Rollback now carry checkpoint: Checkpoint<ChainBlockMetadata> instead of index: u64; Finalized carries Checkpoint<ChainBlockMetadata> instead of ChainBlock
  - L1BridgeConfig updated - root and tip fields changed from Option<ChainBlock> to Option<Checkpoint<ChainBlockMetadata>>
  - VirtualChain updated - advance_tip, rollback, tip(), root(), and advance_root all return Checkpoint<ChainBlockMetadata> instead of raw indices or ChainBlock
  - BridgeWorker lifecycle simplified - new() + run(shutdown) collapsed into a single spawn() that owns shutdown as a field, making the bridge callsite a one-liner
  - All integration tests updated to use Checkpoint::new(index, ChainBlockMetadata::new(hash, blue_score)) constructors and checkpoint.index() accessors
