### PR TITLE
Chore/CI: close fmt + clippy coverage gap in excluded crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
+      - name: Install taplo
+        run: cargo install --locked taplo-cli
+
       - name: Format check
-        run: cargo +nightly fmt -- --check
+        run: ./cargo-fmt-all.sh --check
 
   clippy:
     name: Clippy
@@ -44,7 +47,7 @@ jobs:
           shared-key: "rust-cache"
 
       - name: Clippy
-        run: cargo clippy --tests -- -D warnings
+        run: ./cargo-check-all.sh
 
   test:
     name: Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8391,7 +8391,6 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "rkyv",
- "tap",
  "vprogs-core-codec",
  "zerocopy",
 ]

--- a/cargo-check-all.sh
+++ b/cargo-check-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Runs cargo clippy --tests on the workspace and all excluded crates.
-# Excluded crates are detected automatically from the root Cargo.toml.
+# Runs cargo clippy --tests on the workspace and all excluded crates, treating warnings as errors
+# (matches CI policy). Excluded crates are detected automatically from the root Cargo.toml.
 #
 set -euo pipefail
 
@@ -9,7 +9,7 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 # --- Workspace ---
 echo ":: checking workspace"
-cargo clippy --tests
+cargo clippy --tests -- -D warnings
 
 # --- Excluded crates ---
 excluded=$(python3 -c "
@@ -26,7 +26,7 @@ for crate_dir in $excluded; do
   abs="$ROOT/$crate_dir"
   if [ -d "$abs" ]; then
     echo ":: checking excluded crate: $crate_dir"
-    cargo clippy --tests --manifest-path "$abs/Cargo.toml"
+    cargo clippy --tests --manifest-path "$abs/Cargo.toml" -- -D warnings
   fi
 done
 

--- a/cargo-fmt-all.sh
+++ b/cargo-fmt-all.sh
@@ -4,16 +4,37 @@
 # (except vendored dependencies). Excluded crates are detected automatically
 # from the root Cargo.toml.
 #
+# Usage:
+#   ./cargo-fmt-all.sh           # apply formatting in place
+#   ./cargo-fmt-all.sh --check   # exit non-zero if any file would change (for CI)
+#
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 
+# Parse mode.
+CARGO_FMT_ARGS=()
+TAPLO_FMT_ARGS=()
+case "${1:-}" in
+  --check)
+    CARGO_FMT_ARGS=(-- --check)
+    TAPLO_FMT_ARGS=(--check)
+    ;;
+  "")
+    ;;
+  *)
+    echo "unknown argument: $1" >&2
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
 # --- Workspace ---
 echo ":: formatting workspace (cargo +nightly fmt)"
-cargo +nightly fmt
+cargo +nightly fmt "${CARGO_FMT_ARGS[@]}"
 
 echo ":: formatting TOML files (taplo fmt)"
-taplo fmt
+taplo fmt "${TAPLO_FMT_ARGS[@]}"
 
 # --- Excluded crates ---
 # Parse the exclude array from Cargo.toml and format each non-vendored crate.
@@ -31,8 +52,8 @@ for crate_dir in $excluded; do
   abs="$ROOT/$crate_dir"
   if [ -d "$abs" ]; then
     echo ":: formatting excluded crate: $crate_dir"
-    cargo +nightly fmt --manifest-path "$abs/Cargo.toml"
-    taplo fmt "$abs/Cargo.toml"
+    cargo +nightly fmt --manifest-path "$abs/Cargo.toml" "${CARGO_FMT_ARGS[@]}"
+    taplo fmt "${TAPLO_FMT_ARGS[@]}" "$abs/Cargo.toml"
   fi
 done
 

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -6,6 +6,5 @@ version.workspace = true
 [dependencies]
 borsh             = { workspace = true, default-features = false }
 rkyv              = { workspace = true, default-features = false }
-tap.workspace     = true
 vprogs-core-codec = { workspace = true }
 zerocopy          = { workspace = true }

--- a/zk/backend/risc0/api/Cargo.toml
+++ b/zk/backend/risc0/api/Cargo.toml
@@ -4,6 +4,7 @@ name    = "vprogs-zk-backend-risc0-api"
 version = "0.1.0"
 
 [features]
+cuda = ["risc0-zkvm/cuda"]
 default = ["std"]
 guest = ["dep:risc0-zkvm"]
 host = [
@@ -19,7 +20,6 @@ host = [
   "dep:vprogs-zk-vm",
 ]
 std = ["vprogs-zk-abi/std"]
-cuda = ["risc0-zkvm/cuda"]
 
 [dependencies]
 vprogs-core-codec = { workspace = true }

--- a/zk/backend/risc0/batch-processor/Cargo.lock
+++ b/zk/backend/risc0/batch-processor/Cargo.lock
@@ -1837,7 +1837,6 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "rkyv",
- "tap",
  "vprogs-core-codec",
  "zerocopy",
 ]

--- a/zk/backend/risc0/transaction-processor/Cargo.lock
+++ b/zk/backend/risc0/transaction-processor/Cargo.lock
@@ -1837,7 +1837,6 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "rkyv",
- "tap",
  "vprogs-core-codec",
  "zerocopy",
 ]


### PR DESCRIPTION
## Summary

- CI's `cargo fmt --check` and `cargo clippy` were invoked at the workspace root, which silently skips crates in the root `Cargo.toml`'s `exclude` list (the risc0 guest crates). Formatting and lint regressions in those crates passed CI unnoticed.
- Wire CI to the existing `./cargo-fmt-all.sh` and `./cargo-check-all.sh` scripts, which already iterate the excluded crates. Adds a `--check` mode to `cargo-fmt-all.sh` (forwards to `cargo fmt` and `taplo fmt`) and `-D warnings` to `cargo-check-all.sh` so both behave as gates.
- Drops the unused `tap` dep from `core/types` (caught while wiring this up).
