### PR TITLE
Feat: L1 bridge - settlement tracking

### DIFF
--- a/.claude/skills/code-hygiene/SKILL.md
+++ b/.claude/skills/code-hygiene/SKILL.md
@@ -273,6 +273,167 @@ when:
 Otherwise keep the manual impl — explicit bounds beat derive convenience
 when the derive would over-constrain.
 
+### Match surrounding field-doc voice
+
+Inside a struct, sibling fields establish a voice — typically one short
+sentence naming what the field IS, optionally with a one-clause qualifier.
+When adding a new field, scan the siblings and match their brevity. A
+multi-line doc dropped next to one-line siblings reads as noise even when
+each individual sentence is defensible.
+
+The rule is voice-matching, not a hard length cap: if the surrounding
+fields already carry usage details, match that. If they're terse, be terse.
+
+**Before** (5 lines next to 1-line siblings):
+```rust
+/// Lane tip after applying this block's accepted txs.
+pub lane_tip: Hash,
+/// True when the lane was silent past the finality window at this block.
+pub lane_expired: bool,
+/// Most-recent settlement of the bridge's configured covenant observed at or before this
+/// block, or `None` if none has been observed since the bridge started. Carried forward from
+/// the parent on blocks that contain no new settlement; replaced when a new one lands in this
+/// block. Compare `last_settlement.containing_block` against this block's `hash` to tell the
+/// two cases apart.
+pub last_settlement: Option<SettlementInfo>,
+```
+
+**After**:
+```rust
+/// Lane tip after applying this block's accepted txs.
+pub lane_tip: Hash,
+/// True when the lane was silent past the finality window at this block.
+pub lane_expired: bool,
+/// Most-recent settlement of the configured covenant, or `None` until one lands.
+pub last_settlement: Option<SettlementInfo>,
+```
+
+Why: the carry-forward behavior, the bridge-context, and the "compare
+against block hash" usage hint all migrate to where they actually belong —
+the field's type doc covers the data shape; callers handle their own
+comparisons. The field itself just names what it carries.
+
+### Field docs name what the field IS, not what happens when set
+
+For config / option fields, the doc should describe the field's *identity* —
+what value it carries and what that value means — not the behavior triggered
+when the value is set. The "When set, X is scanned for Y" or "If `Some`, Z
+is invoked" phrasing is a smell: that behavior lives in the consumer that
+READS the field, and its docs are the right place for it.
+
+Naming the role (often by linking to the field that consumes it) is
+shorter, truer, and stays correct when the consumer's algorithm changes.
+
+**Before**:
+```rust
+/// Covenant id this bridge tracks settlements for, or `None` to ignore covenant
+/// activity. When set, accepted transactions in each chain block are scanned
+/// for an output bound to this id; on a match, the settlement is decoded into
+/// the block's [`ChainBlockMetadata::last_settlement`].
+pub covenant_id: Option<Hash>,
+```
+
+**After**:
+```rust
+/// Covenant id surfaced through [`ChainBlockMetadata::last_settlement`], or
+/// `None` to disable.
+pub covenant_id: Option<Hash>,
+```
+
+Why: the WHAT is "the covenant id whose settlements the bridge surfaces
+into the metadata field". The "When set, accepted txs are scanned..." prose
+is implementation of how the field is used, lives in the worker, and would
+need updating if the worker's loop shape changed. The link to
+`last_settlement` does the work.
+
+### Extend existing iterations; don't split filtered loops into two passes
+
+When adding a new derived value alongside an existing iteration (filtering,
+collecting, mapping), prefer a captured accumulator updated inside the
+existing closure over a "collect everything first, iterate again" rewrite.
+Side-effects in closures are idiomatic when the closure is already doing
+similar work, and a single-pass loop preserves the original control flow
+reviewers already understand.
+
+This applies especially to **filtered** collections: building an unfiltered
+intermediate `Vec` just to satisfy a second scan doubles allocation and
+obscures the filter shape. Push the second concern into the same
+`filter_map` closure via a mutable accumulator captured from the enclosing
+scope.
+
+When the second concern is "carry the latest value forward across
+iterations, defaulting to a prior state if none observed", seed the
+accumulator from the prior state and update via `.or(accumulator)` inside
+the loop — that one expression handles both "overwrite when something new
+is found" and "preserve when nothing matches", and the variable holds the
+final answer without an extra `.or(prior_state)` at the call site.
+
+**Before** (single-pass `filter_map` ballooned into two passes to add
+settlement detection + a separate `.or(parent.last_settlement)` at the
+struct site):
+```rust
+let l1_txs: Vec<(u32, L1Transaction)> = chain_block
+    .accepted_transactions
+    .iter()
+    .enumerate()
+    .map(|(idx, tx)| (idx as u32, L1Transaction::try_from(tx.clone()).expect("missing tx fields")))
+    .collect();
+
+let new_settlement = self.covenant_id.as_ref().and_then(|cid| {
+    l1_txs.iter().find_map(|(_, tx)| detect_settlement(cid, block_hash, tx))
+});
+
+let accepted_transactions: Vec<(u32, L1Transaction)> = l1_txs
+    .into_iter()
+    .filter(|(_, tx)| match self.subnetwork_filter.as_ref() {
+        Some(want) => tx.subnetwork_id == *want,
+        None => true,
+    })
+    .collect();
+
+// ...later, at the struct construction:
+let checkpoint = self.virtual_chain.advance_tip(ChainBlockMetadata {
+    last_settlement: new_settlement.or(parent_meta.last_settlement),
+    // ...
+});
+```
+
+**After** (single pass; accumulator seeded from parent state and updated in place):
+```rust
+let mut last_settlement = parent_meta.last_settlement;
+let accepted_transactions: Vec<(u32, L1Transaction)> = chain_block
+    .accepted_transactions
+    .iter()
+    .enumerate()
+    .filter_map(|(idx, tx)| {
+        let tx = L1Transaction::try_from(tx.clone()).expect("missing tx fields");
+        if let Some(id) = &self.covenant_id {
+            last_settlement = tx.settlement_info(id, block_hash).or(last_settlement);
+        }
+        match self.subnetwork_filter.as_ref() {
+            Some(want) if tx.subnetwork_id != *want => None,
+            _ => Some((idx as u32, tx)),
+        }
+    })
+    .collect();
+
+// ...later, at the struct construction:
+let checkpoint = self.virtual_chain.advance_tip(ChainBlockMetadata {
+    last_settlement,
+    // ...
+});
+```
+
+Why: the After version preserves the original `filter_map` shape, allocates
+one Vec instead of two, and folds the carry-forward semantics into the
+accumulator's seed + the `.or(last_settlement)` accumulation. The struct
+site just uses the variable — no extra coalesce step needed.
+
+**Exception**: when the second concern needs a *complete* collection up
+front (e.g., sort then process, check uniqueness then dedupe), two passes
+are the right answer. The rule targets cases where the second concern can
+be folded into the existing closure without changing semantics.
+
 ## Concrete examples from prior cleanups
 
 ### Example 1 — algorithm restated at two levels

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8481,7 +8481,9 @@ dependencies = [
  "kaspa-consensus-core",
  "kaspa-hashes",
  "kaspa-rpc-core",
+ "kaspa-txscript",
  "kaspa-wrpc-client",
+ "zerocopy",
 ]
 
 [[package]]

--- a/l1/bridge/src/config.rs
+++ b/l1/bridge/src/config.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use kaspa_consensus_core::{config::params::Params, subnets::SubnetworkId};
 use vprogs_core_types::Checkpoint;
-use vprogs_l1_types::{ChainBlockMetadata, ConnectStrategy, NetworkId, NetworkType};
+use vprogs_l1_types::{ChainBlockMetadata, ConnectStrategy, Hash, NetworkId, NetworkType};
 
 /// Configuration for the L1 bridge.
 #[derive(Clone, Debug)]
@@ -28,6 +28,8 @@ pub struct L1BridgeConfig {
     pub subnetwork_id: Option<SubnetworkId>,
     /// Blue-score window within which a lane stays active without new transactions.
     pub finality_depth: u64,
+    /// Covenant id tracked by [`ChainBlockMetadata::last_settlement`], or `None` to disable.
+    pub covenant_id: Option<Hash>,
 }
 
 impl Default for L1BridgeConfig {
@@ -43,6 +45,7 @@ impl Default for L1BridgeConfig {
             filter_half_life: Duration::from_secs(3600), // 1 hour.
             subnetwork_id: None,
             finality_depth: Params::from(NetworkId::new(NetworkType::Mainnet)).finality_depth(),
+            covenant_id: None,
         }
     }
 }
@@ -107,6 +110,12 @@ impl L1BridgeConfig {
     /// Sets the lane-expiration blue-score window.
     pub fn with_finality_depth(mut self, finality_depth: u64) -> Self {
         self.finality_depth = finality_depth;
+        self
+    }
+
+    /// Sets the covenant id to track settlements for. `None` disables covenant tracking.
+    pub fn with_covenant_id(mut self, covenant_id: Option<Hash>) -> Self {
+        self.covenant_id = covenant_id;
         self
     }
 }

--- a/l1/bridge/src/worker.rs
+++ b/l1/bridge/src/worker.rs
@@ -59,8 +59,7 @@ pub(crate) struct BridgeWorker {
     lane_key: Option<Hash>,
     /// Blue-score window within which a lane stays active without new transactions.
     finality_depth: u64,
-    /// Covenant id whose last settlement gets tracked by `ChainBlockMetadata::last_settlement` or
-    /// `None` to disable covenant tracking.
+    /// Covenant id tracked by [`ChainBlockMetadata::last_settlement`], or `None` to disable.
     covenant_id: Option<Hash>,
 }
 

--- a/l1/bridge/src/worker.rs
+++ b/l1/bridge/src/worker.rs
@@ -19,7 +19,7 @@ use kaspa_seq_commit::{
 use kaspa_wrpc_client::prelude::*;
 use tokio::sync::Notify;
 use vprogs_core_types::Checkpoint;
-use vprogs_l1_types::{ChainBlockMetadata, Hash, L1Transaction};
+use vprogs_l1_types::{ChainBlockMetadata, Hash, L1Transaction, L1TransactionCovenantExt};
 use workflow_core::channel::{Channel, MultiplexerChannel};
 
 use crate::{
@@ -59,6 +59,9 @@ pub(crate) struct BridgeWorker {
     lane_key: Option<Hash>,
     /// Blue-score window within which a lane stays active without new transactions.
     finality_depth: u64,
+    /// Covenant id whose last settlement gets tracked by `ChainBlockMetadata::last_settlement` or
+    /// `None` to disable covenant tracking.
+    covenant_id: Option<Hash>,
 }
 
 impl BridgeWorker {
@@ -138,6 +141,7 @@ impl BridgeWorker {
             subnetwork_filter: config.subnetwork_id,
             lane_key,
             finality_depth: config.finality_depth,
+            covenant_id: config.covenant_id,
         }
         .run()
         .await;
@@ -365,6 +369,8 @@ impl BridgeWorker {
             // Selected parent on the chain stream is the current virtual-chain tip.
             let header = &chain_block.chain_block_header;
             let parent_meta = *self.virtual_chain.tip().metadata();
+            let block_hash = header.hash.expect("missing hash");
+            let mut last_settlement = parent_meta.last_settlement;
 
             // Enumerate before filtering so kept txs retain their block-wide positions.
             let accepted_transactions: Vec<(u32, L1Transaction)> = chain_block
@@ -373,6 +379,9 @@ impl BridgeWorker {
                 .enumerate()
                 .filter_map(|(idx, tx)| {
                     let tx = L1Transaction::try_from(tx.clone()).expect("missing tx fields");
+                    if let Some(id) = self.covenant_id {
+                        last_settlement = tx.settlement_info(id, block_hash).or(last_settlement);
+                    }
                     match self.subnetwork_filter.as_ref() {
                         Some(want) if tx.subnetwork_id != *want => None,
                         _ => Some((idx as u32, tx)),
@@ -392,6 +401,7 @@ impl BridgeWorker {
                 lane_blue_score,
                 lane_tip,
                 lane_expired,
+                last_settlement,
                 ..ChainBlockMetadata::try_from(header).unwrap()
             });
 

--- a/l1/types/Cargo.toml
+++ b/l1/types/Cargo.toml
@@ -8,4 +8,6 @@ borsh.workspace                = true
 kaspa-consensus-core.workspace = true
 kaspa-hashes.workspace         = true
 kaspa-rpc-core.workspace       = true
+kaspa-txscript.workspace       = true
 kaspa-wrpc-client.workspace    = true
+zerocopy.workspace             = true

--- a/l1/types/src/chain_block_metadata.rs
+++ b/l1/types/src/chain_block_metadata.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_rpc_core::{RpcHeader, RpcOptionalHeader};
 
-use crate::Hash;
+use crate::{Hash, SettlementInfo};
 
 /// Per-block metadata the bridge attaches to each L1 chain block.
 ///
@@ -35,6 +35,8 @@ pub struct ChainBlockMetadata {
     pub lane_tip: Hash,
     /// True when the lane was silent past the finality window at this block.
     pub lane_expired: bool,
+    /// Most-recent settlement of the configured covenant, or `None` until one lands.
+    pub last_settlement: Option<SettlementInfo>,
 }
 
 impl From<&RpcHeader> for ChainBlockMetadata {

--- a/l1/types/src/l1_transaction_covenant_ext.rs
+++ b/l1/types/src/l1_transaction_covenant_ext.rs
@@ -1,0 +1,267 @@
+//! Covenant-settlement detection on [`L1Transaction`].
+//!
+//! A settlement of covenant `X` (see `zk/backend/risc0/covenant/src/settlement.rs`) always:
+//!  1. binds at least one output to `X` via `TransactionOutput::covenant`, and
+//!  2. ends its input-0 `signature_script` with the four-push tail `[new_lane_tip(32),
+//!     new_state(32), block_prove_to(32), prev_redeem(var)]`.
+//!
+//! The first property is the cheap structural signal we trigger off; the second lets us decode the
+//! data the prover needs to know "up to which L1 block has this covenant already been settled by
+//! another prover" without inspecting on-chain UTXO state.
+
+use crate::{Hash, L1Transaction, SettlementInfo};
+
+/// Covenant-aware extension methods for [`L1Transaction`].
+pub trait L1TransactionCovenantExt {
+    /// Decodes `self` as a settlement of `covenant_id`, or `None` if it isn't one.
+    fn settlement_info(&self, covenant_id: Hash, containing_block: Hash) -> Option<SettlementInfo>;
+}
+
+impl L1TransactionCovenantExt for L1Transaction {
+    fn settlement_info(&self, covenant_id: Hash, containing_block: Hash) -> Option<SettlementInfo> {
+        if self.outputs.first()?.covenant.as_ref()?.covenant_id != covenant_id {
+            return None;
+        }
+
+        let input = self.inputs.first()?;
+        let tail = sig_script_tail_4(&input.signature_script)?;
+        let new_lane_tip: [u8; 32] = tail[0].try_into().ok()?;
+        let new_state: [u8; 32] = tail[1].try_into().ok()?;
+        let block_prove_to: [u8; 32] = tail[2].try_into().ok()?;
+
+        Some(SettlementInfo {
+            tx_id: self.id(),
+            containing_block,
+            block_prove_to: Hash::from_bytes(block_prove_to),
+            new_state,
+            new_lane_tip: Hash::from_bytes(new_lane_tip),
+        })
+    }
+}
+
+/// Returns the payloads of the last four data pushes in `script`, or `None` if `script` contains
+/// fewer than four pushes or any byte is a non-push opcode.
+///
+/// Kaspa data-push opcodes (mirrors `kaspa_txscript::opcodes::codes`):
+/// - `0x00`: empty push.
+/// - `0x01..=0x4b`: literal push, opcode byte is the payload length (`OpData1..OpData75`).
+/// - `0x4c`: `OpPushData1`, 1-byte length prefix.
+/// - `0x4d`: `OpPushData2`, 2-byte little-endian length prefix.
+/// - `0x4e`: `OpPushData4`, 4-byte little-endian length prefix.
+fn sig_script_tail_4(script: &[u8]) -> Option<[&[u8]; 4]> {
+    let mut tail: [&[u8]; 4] = [&[]; 4];
+    let mut count = 0usize;
+    let mut i = 0usize;
+    while i < script.len() {
+        let opcode = script[i];
+        i += 1;
+        let (len, prefix_bytes) = match opcode {
+            0x00 => (0, 0),
+            0x01..=0x4b => (opcode as usize, 0),
+            0x4c => (*script.get(i)? as usize, 1),
+            0x4d => {
+                let bytes: [u8; 2] = script.get(i..i + 2)?.try_into().ok()?;
+                (u16::from_le_bytes(bytes) as usize, 2)
+            }
+            0x4e => {
+                let bytes: [u8; 4] = script.get(i..i + 4)?.try_into().ok()?;
+                (u32::from_le_bytes(bytes) as usize, 4)
+            }
+            _ => return None,
+        };
+        i += prefix_bytes;
+        let end = i.checked_add(len)?;
+        if end > script.len() {
+            return None;
+        }
+        let payload = &script[i..end];
+        tail.copy_within(1..4, 0);
+        tail[3] = payload;
+        count += 1;
+        i = end;
+    }
+    if count < 4 { None } else { Some(tail) }
+}
+
+#[cfg(test)]
+mod tests {
+    use kaspa_consensus_core::{
+        constants::TX_VERSION_TOCCATA,
+        subnets::SUBNETWORK_ID_NATIVE,
+        tx::{
+            CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint,
+            TransactionOutput,
+        },
+    };
+
+    use super::*;
+
+    const COVENANT_ID: Hash = Hash::from_bytes([0xAA; 32]);
+    const CONTAINING_BLOCK: Hash = Hash::from_bytes([0x44; 32]);
+    const NEW_LANE_TIP: [u8; 32] = [0x11; 32];
+    const NEW_STATE: [u8; 32] = [0x22; 32];
+    const BLOCK_PROVE_TO: [u8; 32] = [0x33; 32];
+    const PREV_REDEEM: &[u8] = &[0xCC; 200];
+
+    /// Encodes one data push using the canonical opcode for `data.len()`.
+    fn push(buf: &mut Vec<u8>, data: &[u8]) {
+        match data.len() {
+            0 => buf.push(0x00),
+            n if n <= 0x4b => {
+                buf.push(n as u8);
+                buf.extend_from_slice(data);
+            }
+            n if n <= 0xff => {
+                buf.push(0x4c);
+                buf.push(n as u8);
+                buf.extend_from_slice(data);
+            }
+            n if n <= 0xffff => {
+                buf.push(0x4d);
+                buf.extend_from_slice(&(n as u16).to_le_bytes());
+                buf.extend_from_slice(data);
+            }
+            n => {
+                buf.push(0x4e);
+                buf.extend_from_slice(&(n as u32).to_le_bytes());
+                buf.extend_from_slice(data);
+            }
+        }
+    }
+
+    fn build_sig_script(leading: &[&[u8]]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for item in leading {
+            push(&mut buf, item);
+        }
+        push(&mut buf, &NEW_LANE_TIP);
+        push(&mut buf, &NEW_STATE);
+        push(&mut buf, &BLOCK_PROVE_TO);
+        push(&mut buf, PREV_REDEEM);
+        buf
+    }
+
+    fn settlement_tx(sig_script: Vec<u8>, covenant_id: Hash) -> L1Transaction {
+        Transaction::new(
+            TX_VERSION_TOCCATA,
+            vec![TransactionInput::new(
+                TransactionOutpoint::new(Hash::from_bytes([0x66; 32]), 0),
+                sig_script,
+                0,
+                1,
+            )],
+            vec![TransactionOutput::with_covenant(
+                100_000_000,
+                ScriptPublicKey::default(),
+                Some(CovenantBinding::new(0, covenant_id)),
+            )],
+            0,
+            SUBNETWORK_ID_NATIVE,
+            0,
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn extracts_tail_from_groth16_layout() {
+        let sig_script = build_sig_script(&[&[0xEE; 800]]);
+        let tx = settlement_tx(sig_script, COVENANT_ID);
+
+        let settlement = tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).expect("groth16 tail");
+
+        assert_eq!(settlement.tx_id, tx.id());
+        assert_eq!(settlement.containing_block, CONTAINING_BLOCK);
+        assert_eq!(settlement.new_lane_tip, Hash::from_bytes(NEW_LANE_TIP));
+        assert_eq!(settlement.new_state, NEW_STATE);
+        assert_eq!(settlement.block_prove_to, Hash::from_bytes(BLOCK_PROVE_TO));
+    }
+
+    #[test]
+    fn extracts_tail_from_succinct_layout() {
+        let sig_script = build_sig_script(&[
+            &[0x01; 32],         // claim
+            &0u32.to_le_bytes(), // control_index
+            &[0x02; 64],         // control_digests
+            &[0x03; 200_000],    // seal (large)
+        ]);
+        let tx = settlement_tx(sig_script, COVENANT_ID);
+
+        let settlement = tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).expect("succinct tail");
+
+        assert_eq!(settlement.block_prove_to, Hash::from_bytes(BLOCK_PROVE_TO));
+        assert_eq!(settlement.containing_block, CONTAINING_BLOCK);
+    }
+
+    #[test]
+    fn ignores_tx_without_matching_binding() {
+        let sig_script = build_sig_script(&[]);
+        let tx = settlement_tx(sig_script, Hash::from_bytes([0x77; 32]));
+
+        assert!(tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).is_none());
+    }
+
+    #[test]
+    fn ignores_tx_with_no_outputs_at_all() {
+        let tx = Transaction::new(
+            TX_VERSION_TOCCATA,
+            vec![],
+            vec![],
+            0,
+            SUBNETWORK_ID_NATIVE,
+            0,
+            Vec::new(),
+        );
+        assert!(tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).is_none());
+    }
+
+    #[test]
+    fn ignores_bootstrap_style_sig_script() {
+        // A single short push (e.g. a bare signature) doesn't satisfy the four-push tail.
+        let mut sig_script = Vec::new();
+        push(&mut sig_script, &[0xDD; 64]);
+        let tx = settlement_tx(sig_script, COVENANT_ID);
+
+        assert!(tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).is_none());
+    }
+
+    #[test]
+    fn rejects_truncated_push_length_prefix() {
+        let mut script = Vec::new();
+        push(&mut script, &[0xAB; 16]);
+        push(&mut script, &[0xCD; 16]);
+        push(&mut script, &[0xEF; 16]);
+        script.push(0x4d); // OpPushData2 without its 2-byte length suffix
+        assert!(sig_script_tail_4(&script).is_none());
+    }
+
+    #[test]
+    fn rejects_non_push_opcode() {
+        let mut script = build_sig_script(&[]);
+        script.push(0x69); // OpVerify - any non-push byte.
+        assert!(sig_script_tail_4(&script).is_none());
+    }
+
+    #[test]
+    fn accepts_pushdata1_and_pushdata2_for_32_byte_items() {
+        // Hand-encode the three 32-byte items via OpPushData1 / OpPushData2 instead of OpData32.
+        // The parser is opcode-agnostic; it should still extract the payloads.
+        let mut script = Vec::new();
+        script.push(0x4c);
+        script.push(32);
+        script.extend_from_slice(&NEW_LANE_TIP);
+        script.push(0x4d);
+        script.extend_from_slice(&32u16.to_le_bytes());
+        script.extend_from_slice(&NEW_STATE);
+        script.push(0x4c);
+        script.push(32);
+        script.extend_from_slice(&BLOCK_PROVE_TO);
+        push(&mut script, PREV_REDEEM);
+
+        let tx = settlement_tx(script, COVENANT_ID);
+        let settlement =
+            tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).expect("opcode-agnostic tail");
+        assert_eq!(settlement.new_lane_tip, Hash::from_bytes(NEW_LANE_TIP));
+        assert_eq!(settlement.new_state, NEW_STATE);
+        assert_eq!(settlement.block_prove_to, Hash::from_bytes(BLOCK_PROVE_TO));
+    }
+}

--- a/l1/types/src/l1_transaction_covenant_ext.rs
+++ b/l1/types/src/l1_transaction_covenant_ext.rs
@@ -9,6 +9,9 @@
 //! data the prover needs to know "up to which L1 block has this covenant already been settled by
 //! another prover" without inspecting on-chain UTXO state.
 
+use kaspa_consensus_core::{hashing::sighash::SigHashReusedValuesUnsync, tx::PopulatedTransaction};
+use kaspa_txscript::parse_script;
+
 use crate::{Hash, L1Transaction, SettlementInfo};
 
 /// Covenant-aware extension methods for [`L1Transaction`].
@@ -19,68 +22,46 @@ pub trait L1TransactionCovenantExt {
 
 impl L1TransactionCovenantExt for L1Transaction {
     fn settlement_info(&self, covenant_id: Hash, containing_block: Hash) -> Option<SettlementInfo> {
+        // Cheap structural gate: output 0 must bind to the configured covenant.
         if self.outputs.first()?.covenant.as_ref()?.covenant_id != covenant_id {
             return None;
         }
 
-        let input = self.inputs.first()?;
-        let tail = sig_script_tail_4(&input.signature_script)?;
-        let new_lane_tip: [u8; 32] = tail[0].try_into().ok()?;
-        let new_state: [u8; 32] = tail[1].try_into().ok()?;
-        let block_prove_to: [u8; 32] = tail[2].try_into().ok()?;
+        // Decode the three 32-byte values pushed before the redeem in input 0's sig_script.
+        let (new_lane_tip, new_state, block_prove_to) =
+            parse_settlement_tail(&self.inputs.first()?.signature_script)?;
 
         Some(SettlementInfo {
             tx_id: self.id(),
             containing_block,
-            block_prove_to: Hash::from_bytes(block_prove_to),
+            block_prove_to,
             new_state,
-            new_lane_tip: Hash::from_bytes(new_lane_tip),
+            new_lane_tip,
         })
     }
 }
 
-/// Returns the payloads of the last four data pushes in `script`, or `None` if `script` contains
-/// fewer than four pushes or any byte is a non-push opcode.
-///
-/// Kaspa data-push opcodes (mirrors `kaspa_txscript::opcodes::codes`):
-/// - `0x00`: empty push.
-/// - `0x01..=0x4b`: literal push, opcode byte is the payload length (`OpData1..OpData75`).
-/// - `0x4c`: `OpPushData1`, 1-byte length prefix.
-/// - `0x4d`: `OpPushData2`, 2-byte little-endian length prefix.
-/// - `0x4e`: `OpPushData4`, 4-byte little-endian length prefix.
-fn sig_script_tail_4(script: &[u8]) -> Option<[&[u8]; 4]> {
-    let mut tail: [&[u8]; 4] = [&[]; 4];
-    let mut count = 0usize;
-    let mut i = 0usize;
-    while i < script.len() {
-        let opcode = script[i];
-        i += 1;
-        let (len, prefix_bytes) = match opcode {
-            0x00 => (0, 0),
-            0x01..=0x4b => (opcode as usize, 0),
-            0x4c => (*script.get(i)? as usize, 1),
-            0x4d => {
-                let bytes: [u8; 2] = script.get(i..i + 2)?.try_into().ok()?;
-                (u16::from_le_bytes(bytes) as usize, 2)
-            }
-            0x4e => {
-                let bytes: [u8; 4] = script.get(i..i + 4)?.try_into().ok()?;
-                (u32::from_le_bytes(bytes) as usize, 4)
-            }
-            _ => return None,
-        };
-        i += prefix_bytes;
-        let end = i.checked_add(len)?;
-        if end > script.len() {
+/// Returns `(new_lane_tip, new_state, block_prove_to)` from the three 32-byte pushes preceding the
+/// redeem-script push, or `None` if the sig_script doesn't end in that layout.
+fn parse_settlement_tail(script: &[u8]) -> Option<(Hash, [u8; 32], Hash)> {
+    // Sliding window over the last four push payloads; only 32-byte pushes occupy a slot.
+    let mut window: [Option<[u8; 32]>; 4] = [None; 4];
+    for op in parse_script::<PopulatedTransaction<'_>, SigHashReusedValuesUnsync>(script) {
+        // Reject anything other than a clean data push.
+        let op = op.ok()?;
+        if !op.is_push_opcode() {
             return None;
         }
-        let payload = &script[i..end];
-        tail.copy_within(1..4, 0);
-        tail[3] = payload;
-        count += 1;
-        i = end;
+
+        // Slide the window left, record the new push in slot 3.
+        window[0] = window[1].take();
+        window[1] = window[2].take();
+        window[2] = window[3].take();
+        window[3] = op.get_data().try_into().ok();
     }
-    if count < 4 { None } else { Some(tail) }
+
+    // Slots 0..2 hold the three settlement values; slot 3 (the redeem) is ignored.
+    Some((Hash::from_bytes(window[0]?), window[1]?, Hash::from_bytes(window[2]?)))
 }
 
 #[cfg(test)]
@@ -226,19 +207,18 @@ mod tests {
 
     #[test]
     fn rejects_truncated_push_length_prefix() {
-        let mut script = Vec::new();
-        push(&mut script, &[0xAB; 16]);
-        push(&mut script, &[0xCD; 16]);
-        push(&mut script, &[0xEF; 16]);
+        let mut script = build_sig_script(&[]);
         script.push(0x4d); // OpPushData2 without its 2-byte length suffix
-        assert!(sig_script_tail_4(&script).is_none());
+        let tx = settlement_tx(script, COVENANT_ID);
+        assert!(tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).is_none());
     }
 
     #[test]
     fn rejects_non_push_opcode() {
         let mut script = build_sig_script(&[]);
         script.push(0x69); // OpVerify - any non-push byte.
-        assert!(sig_script_tail_4(&script).is_none());
+        let tx = settlement_tx(script, COVENANT_ID);
+        assert!(tx.settlement_info(COVENANT_ID, CONTAINING_BLOCK).is_none());
     }
 
     #[test]

--- a/l1/types/src/lib.rs
+++ b/l1/types/src/lib.rs
@@ -2,12 +2,18 @@ mod chain_block_metadata;
 mod connect_strategy;
 mod hash;
 mod l1_transaction;
+mod l1_transaction_covenant_ext;
 mod network_id;
 mod network_type;
+mod settlement_info;
+mod transaction_id;
 
 pub use chain_block_metadata::ChainBlockMetadata;
 pub use connect_strategy::ConnectStrategy;
 pub use hash::Hash;
 pub use l1_transaction::L1Transaction;
+pub use l1_transaction_covenant_ext::L1TransactionCovenantExt;
 pub use network_id::NetworkId;
 pub use network_type::NetworkType;
+pub use settlement_info::SettlementInfo;
+pub use transaction_id::TransactionId;

--- a/l1/types/src/settlement_info.rs
+++ b/l1/types/src/settlement_info.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{Hash, TransactionId};
 
@@ -6,7 +7,10 @@ use crate::{Hash, TransactionId};
 ///
 /// Bundles the post-state pair `(new_state, new_lane_tip)` the settlement advances the covenant to
 /// with the L1 block (`block_prove_to`) the proof was committed against.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 pub struct SettlementInfo {
     /// L1 transaction id of the settlement.
     pub tx_id: TransactionId,

--- a/l1/types/src/settlement_info.rs
+++ b/l1/types/src/settlement_info.rs
@@ -1,0 +1,21 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::{Hash, TransactionId};
+
+/// Decoded view of a settlement transaction observed on L1.
+///
+/// Bundles the post-state pair `(new_state, new_lane_tip)` the settlement advances the covenant to
+/// with the L1 block (`block_prove_to`) the proof was committed against.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SettlementInfo {
+    /// L1 transaction id of the settlement.
+    pub tx_id: TransactionId,
+    /// L1 chain block that contained the settlement transaction.
+    pub containing_block: Hash,
+    /// L1 chain block hash the settlement proves up to.
+    pub block_prove_to: Hash,
+    /// L2 SMT state root after this settlement.
+    pub new_state: [u8; 32],
+    /// Lane tip after this settlement.
+    pub new_lane_tip: Hash,
+}

--- a/l1/types/src/transaction_id.rs
+++ b/l1/types/src/transaction_id.rs
@@ -1,0 +1,1 @@
+pub use kaspa_consensus_core::tx::TransactionId;

--- a/node/cli/src/l1_bridge_params.rs
+++ b/node/cli/src/l1_bridge_params.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use serde::{Deserialize, Serialize};
 use vprogs_l1_bridge::L1BridgeConfig;
-use vprogs_l1_types::NetworkId;
+use vprogs_l1_types::{Hash, NetworkId};
 
 use crate::extensions::ConnectStrategyExt;
 
@@ -37,6 +37,10 @@ pub struct L1BridgeParams {
     /// Blue-score window within which a lane stays active without new transactions.
     #[arg(long = "l1-bridge-finality-depth", default_value_t = L1BridgeConfig::default().finality_depth)]
     pub finality_depth: u64,
+    /// Covenant id (64-char hex) whose last settlement gets tracked by each chain block's
+    /// metadata. Omit to disable covenant tracking.
+    #[arg(long = "l1-bridge-covenant-id")]
+    pub covenant_id: Option<Hash>,
 }
 
 impl L1BridgeParams {
@@ -54,6 +58,7 @@ impl L1BridgeParams {
             tip: None,
             subnetwork_id: self.subnetwork_id,
             finality_depth: self.finality_depth,
+            covenant_id: self.covenant_id,
         }
     }
 }


### PR DESCRIPTION
## Summary

  - Add `SettlementInfo` + `L1TransactionCovenantExt::settlement_info(covenant_id, containing_block)` to decode covenant settlements from accepted L1 transactions.
  - Track the most-recent settlement of a configured covenant on `ChainBlockMetadata::last_settlement`, carried forward across blocks with no new settlement.
  - New `L1BridgeConfig::covenant_id` (+ `--l1-bridge-covenant-id` CLI flag) opts the bridge into tracking; default `None` keeps existing behaviour.
