### PR TITLE
Fix: SMT leaf deletion resurrecting stale state via a missing tombstone

### DIFF
--- a/core/smt/src/key.rs
+++ b/core/smt/src/key.rs
@@ -5,7 +5,7 @@ use vprogs_core_codec::{Bits, Reader, Result};
 ///
 /// Level 0 is the root, level 256 is a full-depth leaf. The path encodes left/right decisions
 /// (0 = left, 1 = right); only the first `level` bits are significant.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Key {
     /// Depth from root (0 = root, 256 = full-depth leaf).
     pub level: u16,

--- a/core/smt/src/updater.rs
+++ b/core/smt/src/updater.rs
@@ -184,7 +184,15 @@ impl<'a, S: Tree, W: WriteBatch> Updater<'a, S, W> {
     /// Writes a child node to the tree and returns its [`HashedNode`] summary.
     fn write_child(&mut self, child: &Option<Node>, key: &Key) -> HashedNode {
         match child {
-            None => HashedNode::EMPTY,
+            None => {
+                // Tombstone an emptied position so a later read can't resurface the deleted node.
+                let exists = |(_, node)| !matches!(node, Node::Empty);
+                if self.tree.node(key, self.prev_version).is_some_and(exists) {
+                    self.wb.put_node(key, self.version, &Node::Empty);
+                    self.wb.put_stale_node(&StaleNode::new(self.version, *key, self.version));
+                }
+                HashedNode::EMPTY
+            }
             Some(node) => {
                 self.wb.put_node(key, self.version, node);
                 HashedNode::from(node)
@@ -195,7 +203,7 @@ impl<'a, S: Tree, W: WriteBatch> Updater<'a, S, W> {
     /// Marks an existing node at the given position as stale (if it exists).
     fn mark_stale(&mut self, node_key: &Key) {
         if let Some((old_version, _)) = self.tree.node(node_key, self.prev_version) {
-            self.wb.put_stale_node(&StaleNode::new(self.version, node_key.clone(), old_version));
+            self.wb.put_stale_node(&StaleNode::new(self.version, *node_key, old_version));
         }
     }
 }

--- a/core/smt/tests/delete_with_promotion.rs
+++ b/core/smt/tests/delete_with_promotion.rs
@@ -1,4 +1,4 @@
-//! Regression tests for deletes that trigger SMT shortcut-promotion.
+//! Regression tests for SMT delete behaviour: shortcut-promotion and stale-leaf retention.
 //!
 //! When a `Present` query writes `EMPTY_HASH` and its sibling at some depth is a single `Leaf`,
 //! the SMT promotes that leaf upward (potentially many levels). Without kind-aware hashing in
@@ -164,4 +164,87 @@ fn delete_only_key_yields_empty_root() {
     let computed = proof.new_root::<Sha256>(|_| &EMPTY_HASH).unwrap();
     assert_eq!(computed, EMPTY_HASH);
     assert_eq!(computed, smt_root);
+}
+
+/// Builds the bug's shape: a single key on the bit-0 = 0 half (a root-level shortcut leaf) opposite
+/// a two-key `Internal` subtree on the bit-0 = 1 half. Returns `(k_drop, k_sub_a, k_sub_b)`.
+fn store_with_leaf_opposite_subtree() -> (TempDir, RocksDbStore, ResourceId, ResourceId, ResourceId)
+{
+    // k_drop is the only key on its half, so it sits as a shortcut leaf directly under the root.
+    // The other half holds two keys that diverge only at byte 31, forming an `Internal` subtree
+    // - the sibling that blocks promotion when k_drop is deleted.
+    let k_drop = key(0x00, 0xAA);
+    let k_sub_a = key(0x80, 0xCC);
+    let k_sub_b = key(0x80, 0xDD);
+    let dir = TempDir::new().unwrap();
+    let store: RocksDbStore = RocksDbStore::open(dir.path());
+    let mut wb = store.write_batch();
+    store.update(
+        &mut wb,
+        vec![
+            Commitment::new(k_drop, [0x22; 32]),
+            Commitment::new(k_sub_a, [0x33; 32]),
+            Commitment::new(k_sub_b, [0x44; 32]),
+        ],
+        1,
+    );
+    store.commit(wb);
+    (dir, store, k_drop, k_sub_a, k_sub_b)
+}
+
+/// Deleting a leaf whose immediate sibling is an `Internal` subtree leaves the parent as
+/// `Internal(EMPTY, sibling)` - no promotion fires, so the deleted leaf's own position is abandoned
+/// without a tombstone. Reading that version must still see the key as gone; without a tombstone
+/// the `latest <= version` seek surfaces the stale pre-deletion leaf and resurrects the resource.
+#[test]
+fn delete_with_internal_sibling_does_not_resurrect_at_same_version() {
+    let (_dir, store, k_drop, ..) = store_with_leaf_opposite_subtree();
+
+    // Delete k_drop at v=2; its position is abandoned with no tombstone written.
+    let mut wb = store.write_batch();
+    store.update(&mut wb, vec![Commitment::new(k_drop, EMPTY_HASH)], 2);
+    store.commit(wb);
+
+    // Prove k_drop AT v=2 (after the delete). It must witness as empty, and the proof's pre-state
+    // root must match the committed root - both fail if the stale leaf is resurfaced.
+    let proof_bytes = store.prove(&[k_drop], 2).unwrap();
+    let proof = Proof::decode(&proof_bytes).unwrap();
+    assert_eq!(
+        proof.member(0).unwrap().value_hash(),
+        &EMPTY_HASH,
+        "key deleted at v=2 must read as empty at v=2, not resurrect its pre-deletion value",
+    );
+    assert_eq!(
+        proof.root::<Sha256>().unwrap(),
+        store.root(2),
+        "proof's pre-state root must match the committed root after deletion",
+    );
+}
+
+/// The same un-tombstoned position is also re-incorporated by a *later* update that touches the
+/// parent region: the updater reads the abandoned position at `prev_version` and carries the stale
+/// leaf forward, silently resurrecting the deleted resource at a version where nothing re-created
+/// it.
+#[test]
+fn delete_with_internal_sibling_does_not_resurrect_at_later_version() {
+    let (_dir, store, k_drop, k_sub_a, _) = store_with_leaf_opposite_subtree();
+
+    // v=2: delete k_drop.
+    let mut wb = store.write_batch();
+    store.update(&mut wb, vec![Commitment::new(k_drop, EMPTY_HASH)], 2);
+    store.commit(wb);
+
+    // v=3: touch only the sibling subtree. The root is rebuilt reading v=2, where k_drop's
+    // abandoned position still holds its stale leaf - it must not be carried into v=3.
+    let mut wb = store.write_batch();
+    store.update(&mut wb, vec![Commitment::new(k_sub_a, [0x55; 32])], 3);
+    store.commit(wb);
+
+    let proof_bytes = store.prove(&[k_drop], 3).unwrap();
+    let proof = Proof::decode(&proof_bytes).unwrap();
+    assert_eq!(
+        proof.member(0).unwrap().value_hash(),
+        &EMPTY_HASH,
+        "key deleted at v=2 must stay absent at v=3, not be resurrected by an unrelated update",
+    );
 }


### PR DESCRIPTION
## Summary

Deleting an SMT leaf could leave its position **untombstoned**, so a later `latest <= version` read would fall back to the stale pre-deletion leaf, **resurrecting a deleted resource**. This is a state-correctness bug, not just hygiene: under the right tree shape a deleted account silently reappears with its old value. This PR writes an `Empty` tombstone at emptied positions (and marks it stale for pruning), generalizing the tombstone the root-drain case already wrote.

## Root cause

On deletion, `Updater::write_child(None, key)` abandoned the emptied position without writing anything - only the whole-tree-drain case (`apply`) wrote an `Empty` tombstone at `Key::ROOT`. Since SMT nodes are keyed `position | !version` and `node()` returns the latest version `<= max_version` via a prefix-seek, an abandoned position keeps returning its stale pre-deletion node.

This only triggers when the deleted leaf's **immediate sibling is an internal subtree**: the parent becomes `Internal(EMPTY, sibling)` and stays internal, so descent keeps walking into the abandoned position. When the sibling is a *leaf*, shortcut-promotion rewrites the parent as that leaf and descent terminates above the abandoned position - which is why the existing promotion tests never caught this.

## Failure modes

- **Same version**: proving/reading the deleted key at the deletion version returns it as *present* with its stale value, so the proof root diverges from the committed root.
- **Later version (silent)**: a subsequent update touching the parent region reads the stale leaf via `update_subtree`'s `prev_version` lookup and writes it forward — the deleted resource reappears at a version where nothing re-created it.

## Fix

`write_child`'s `None` arm now tombstones a previously-occupied position:

```rust
let exists = |(_, node)| !matches!(node, Node::Empty);
if self.tree.node(key, self.prev_version).is_some_and(exists) {
    self.wb.put_node(key, self.version, &Node::Empty);
    self.wb.put_stale_node(&StaleNode::new(self.version, *key, self.version));
}
```

- The `Empty` tombstone shadows the superseded node, so the seek returns "no subtree" instead of the stale leaf. Its summary is still `EMPTY`, so **no root hashes change** — existing roots/proofs are unaffected.
- The tombstone's stale marker uses the same `stale_since` (`self.version`) as the superseded node's existing marker, so `prune(self.version)` reclaims **both together** — there's no window where the old node outlives its tombstone and resurfaces.

## Tests

Two regression tests in `delete_with_promotion.rs` for the internal-sibling (no-promotion) case:

- deleted key reads empty at the deletion version, and the proof's pre-state root matches the committed root;
- deleted key stays empty after an unrelated later update to the sibling subtree.

Both fail against the old code (return the stale `0x22…` value) and pass with the fix.

## Incidental

`Key` now derives `Copy` (it's a 34-byte POD), letting the tombstone code use `*key` instead of `key.clone()`.
