### PR TITLE
Fix: Speed up the storage write path

### DIFF
--- a/scheduling/scheduler/src/batch_lifecycle_worker.rs
+++ b/scheduling/scheduler/src/batch_lifecycle_worker.rs
@@ -10,48 +10,52 @@ use vprogs_storage_types::Store;
 use crate::{Processor, ScheduledBatch};
 
 /// Background worker that drives each batch through its lifecycle stages.
-///
-/// Batches are pushed into a queue and processed sequentially: wait for all transactions to
-/// execute, wait for all state diffs to persist, then submit the batch for commit and wait for
-/// finalization.
 pub(crate) struct BatchLifecycleWorker<S: Store, P: Processor<S>> {
+    /// Queue of batches awaiting lifecycle processing.
     queue: Arc<SegQueue<ScheduledBatch<S, P>>>,
+    /// Wakes the worker when a batch is pushed or on shutdown.
     notify: Arc<Notify>,
+    /// Join handle for the worker thread.
     handle: JoinHandle<()>,
 }
 
 impl<S: Store, P: Processor<S>> BatchLifecycleWorker<S, P> {
+    /// Creates the queue and spawns the lifecycle worker thread.
     pub(crate) fn new() -> Self {
         let queue = Arc::new(SegQueue::new());
         let notify = Arc::new(Notify::new());
         let handle = Self::start(queue.clone(), notify.clone());
-
         Self { queue, notify, handle }
     }
 
+    /// Enqueues a batch and wakes the worker.
     pub(crate) fn push(&self, batch: ScheduledBatch<S, P>) {
         self.queue.push(batch);
         self.notify.notify_one();
     }
 
+    /// Signals shutdown and waits for the worker thread to finish.
     pub(crate) fn shutdown(self) {
+        // Drop our queue handle so the worker's loop sees strong_count == 1 and exits.
         drop(self.queue);
         self.notify.notify_one();
         self.handle.join().expect("batch lifecycle worker panicked");
     }
 
+    /// Spawns the worker thread: drains the queue, awaiting each batch then scheduling its commit.
     fn start(queue: Arc<SegQueue<ScheduledBatch<S, P>>>, notify: Arc<Notify>) -> JoinHandle<()> {
         thread::spawn(move || {
             Builder::new_current_thread().build().expect("failed to build tokio runtime").block_on(
                 async move {
+                    // Run until the owner drops the queue on shutdown (strong_count hits 1).
                     while Arc::strong_count(&queue) != 1 {
+                        // Drain ready batches: await execution, then submit each for commit.
                         while let Some(batch) = queue.pop() {
                             batch.wait_processed().await;
-                            batch.wait_persisted().await;
                             batch.schedule_commit();
-                            batch.wait_committed().await;
                         }
 
+                        // Park until a batch is pushed or shutdown notifies us.
                         if Arc::strong_count(&queue) != 1 {
                             notify.notified().await
                         }

--- a/scheduling/scheduler/src/scheduled_batch.rs
+++ b/scheduling/scheduler/src/scheduled_batch.rs
@@ -21,11 +21,12 @@ use crate::{
 
 /// A batch of transactions progressing through the scheduler's lifecycle.
 ///
-/// Each batch moves through three stages: processed (all transactions executed), persisted (all
-/// state diffs written to disk), and committed (batch metadata finalized). When proving is active,
-/// additional latches track asynchronous transaction and batch artifact publication. Callers can
-/// observe progress via the query / `wait_*` methods. A batch may be canceled by a rollback, in
-/// which case the wait methods return immediately.
+/// Each batch moves through two stages: processed (all transactions executed) and committed (batch
+/// metadata finalized). State-diff writes are handed to the storage manager during execution and
+/// land asynchronously under the eventual-consistency model, so there is no separate persist stage.
+/// When proving is active, additional latches track asynchronous transaction and batch artifact
+/// publication. Callers can observe progress via the query / `wait_*` methods. A batch may be
+/// canceled by a rollback, in which case the wait methods return immediately.
 #[smart_pointer]
 pub struct ScheduledBatch<S: Store, P: Processor<S>> {
     /// Cancellation context captured at creation time for rollback detection.
@@ -38,8 +39,7 @@ pub struct ScheduledBatch<S: Store, P: Processor<S>> {
     txs: Vec<ScheduledTransaction<S, P>>,
     /// One state diff per unique resource accessed by this batch.
     state_diffs: Vec<StateDiff<S, P>>,
-    /// Batch artifact (e.g. batch proof receipt), set via
-    /// [`publish_artifact`](Self::publish_artifact).
+    /// Batch artifact (e.g. batch proof receipt), set via `publish_artifact`.
     artifact: ArcSwapOption<P::BatchArtifact>,
     /// Work-stealing queue of transactions ready for execution.
     available_txs: Injector<ManagerTask<S, P>>,
@@ -47,33 +47,31 @@ pub struct ScheduledBatch<S: Store, P: Processor<S>> {
     pending_txs: AtomicU64,
     /// Number of transactions whose artifacts haven't been published yet.
     pending_tx_artifacts: AtomicU64,
-    /// Number of state diff writes not yet persisted to disk.
-    pending_writes: AtomicU64,
     /// Opens when all transactions have been executed.
     processed: AtomicAsyncLatch,
     /// Opens when all transaction artifacts have been published.
     tx_artifacts_published: AtomicAsyncLatch,
-    /// Opens when the batch artifact has been published via
-    /// [`publish_artifact`](Self::publish_artifact).
+    /// Opens when the batch artifact has been published via `publish_artifact`.
     artifact_published: AtomicAsyncLatch,
-    /// Opens when all state diffs have been written to disk.
-    persisted: AtomicAsyncLatch,
     /// Opens when batch metadata has been committed.
     committed: AtomicAsyncLatch,
 }
 
 impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     /// Returns the checkpoint (index + metadata) identifying this batch.
+    #[inline(always)]
     pub fn checkpoint(&self) -> &Checkpoint<P::BatchMetadata> {
         &self.checkpoint
     }
 
     /// Returns the transactions in this batch.
+    #[inline(always)]
     pub fn txs(&self) -> &[ScheduledTransaction<S, P>] {
         &self.txs
     }
 
     /// Returns the state diffs produced by this batch (one per unique resource).
+    #[inline(always)]
     pub fn state_diffs(&self) -> &[StateDiff<S, P>] {
         &self.state_diffs
     }
@@ -94,21 +92,25 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     }
 
     /// Returns the number of transactions ready for execution.
+    #[inline(always)]
     pub fn num_available(&self) -> u64 {
         self.available_txs.len() as u64
     }
 
     /// Returns the number of transactions not yet fully executed.
+    #[inline(always)]
     pub fn num_pending(&self) -> u64 {
         self.pending_txs.load(Ordering::Acquire)
     }
 
     /// Returns true if this batch was canceled by a rollback.
+    #[inline(always)]
     pub fn canceled(&self) -> bool {
         self.checkpoint.index() > self.cancellation.threshold()
     }
 
     /// Returns true if all transactions have been executed.
+    #[inline(always)]
     pub fn processed(&self) -> bool {
         self.processed.is_open()
     }
@@ -128,27 +130,8 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         self
     }
 
-    /// Returns true if all state diffs have been written to disk.
-    pub fn persisted(&self) -> bool {
-        self.persisted.is_open()
-    }
-
-    /// Waits until all state diffs have been written to disk, or returns immediately if canceled.
-    pub async fn wait_persisted(&self) {
-        if !self.canceled() {
-            self.persisted.wait().await
-        }
-    }
-
-    /// Blocking version of [`wait_persisted`](Self::wait_persisted).
-    pub fn wait_persisted_blocking(&self) -> &Self {
-        if !self.canceled() {
-            self.persisted.wait_blocking();
-        }
-        self
-    }
-
     /// Returns true if the batch metadata has been committed to disk.
+    #[inline(always)]
     pub fn committed(&self) -> bool {
         self.committed.is_open()
     }
@@ -169,12 +152,12 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     }
 
     /// Returns true if all transaction artifacts have been published.
+    #[inline(always)]
     pub fn tx_artifacts_published(&self) -> bool {
         self.tx_artifacts_published.is_open()
     }
 
-    /// Waits until all transaction artifacts have been published, or returns immediately if
-    /// canceled.
+    /// Waits until all transaction artifacts are published, or returns immediately if canceled.
     pub async fn wait_tx_artifacts_published(&self) {
         if !self.canceled() {
             self.tx_artifacts_published.wait().await
@@ -189,10 +172,8 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         self
     }
 
-    /// Returns the batch artifact.
-    ///
-    /// # Panics
-    /// Panics if called before [`publish_artifact`](Self::publish_artifact).
+    /// Returns the batch artifact; panics if called before `publish_artifact`.
+    #[inline(always)]
     pub fn artifact(&self) -> Arc<P::BatchArtifact> {
         self.artifact.load_full().expect("batch artifact not ready")
     }
@@ -206,6 +187,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     }
 
     /// Returns true if the batch artifact has been published.
+    #[inline(always)]
     pub fn artifact_published(&self) -> bool {
         self.artifact_published.is_open()
     }
@@ -232,6 +214,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         }
     }
 
+    /// Creates the batch, building a scheduled transaction and state diffs for each input.
     pub(crate) fn new(
         scheduler: &mut Scheduler<S, P>,
         txs: Vec<SchedulerTransaction<P::Transaction>>,
@@ -239,15 +222,12 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     ) -> Self {
         Self(Arc::new_cyclic(|this| {
             let processed = AtomicAsyncLatch::default();
-            let persisted = AtomicAsyncLatch::default();
             let tx_artifacts_published = AtomicAsyncLatch::default();
             let artifact_published = AtomicAsyncLatch::default();
 
-            // An empty batch has nothing to process, persist, or prove - open the latches
-            // immediately so the lifecycle worker can commit it right away.
+            // An empty batch has nothing to process or prove - open the latches immediately.
             if txs.is_empty() {
                 processed.open();
-                persisted.open();
                 tx_artifacts_published.open();
                 artifact_published.open();
             }
@@ -277,17 +257,16 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                     .collect(),
                 state_diffs,
                 available_txs: Injector::new(),
-                pending_writes: AtomicU64::new(0),
                 processed,
                 tx_artifacts_published,
                 artifact: ArcSwapOption::empty(),
                 artifact_published,
-                persisted,
                 committed: Default::default(),
             }
         }))
     }
 
+    /// Connects each transaction's resources into chains, or makes resource-free txs available.
     pub(crate) fn connect(&self) {
         for tx in self.txs() {
             if tx.resources().is_empty() {
@@ -302,10 +281,13 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         }
     }
 
+    /// Pushes a transaction onto the work-stealing queue of ready transactions.
+    #[inline(always)]
     pub(crate) fn push_available_tx(&self, tx: &ScheduledTransaction<S, P>) {
         self.available_txs.push(ManagerTask::ExecuteTransaction(tx.clone()));
     }
 
+    /// Marks one transaction executed; opens `processed` when the last finishes.
     pub(crate) fn decrease_pending_txs(&self) {
         if self.pending_txs.fetch_sub(1, Ordering::AcqRel) == 1 {
             self.processed.open();
@@ -315,37 +297,24 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                 self.tx_artifacts_published.open();
                 self.artifact_published.open();
             }
-
-            // Also check if persisted should open (handles case where last TX has no writes)
-            if self.pending_writes.load(Ordering::Acquire) == 0 {
-                self.persisted.open();
-            }
         }
     }
 
+    /// Marks one tx artifact published; opens `tx_artifacts_published` when the last finishes.
     pub(crate) fn decrease_pending_tx_artifacts(&self) {
         if self.pending_tx_artifacts.fetch_sub(1, Ordering::AcqRel) == 1 {
             self.tx_artifacts_published.open();
         }
     }
 
+    /// Submits a write to the storage manager. No-op if canceled.
     pub(crate) fn submit_write(&self, write: Write<S, P>) {
         if !self.canceled() {
-            self.pending_writes.fetch_add(1, Ordering::AcqRel);
             self.state.storage().submit_write(write);
         }
     }
 
-    pub(crate) fn decrease_pending_writes(&self) {
-        if self.pending_writes.fetch_sub(1, Ordering::AcqRel) == 1 {
-            // Double-check: once pending_txs == 0, no new writes can be submitted, so if
-            // pending_writes is still 0, it will stay 0.
-            if self.num_pending() == 0 && self.pending_writes.load(Ordering::Acquire) == 0 {
-                self.persisted.open();
-            }
-        }
-    }
-
+    /// Writes the batch's latest pointers, SMT update, state root, and metadata. No-op if canceled.
     pub(crate) fn commit<ST: Store>(&self, store: &ST, wb: &mut ST::WriteBatch) {
         if !self.canceled() {
             // Write the latest ptr entries for all updated resources.
@@ -361,6 +330,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                 self.checkpoint.index(),
             );
 
+            // Record the new state root, this batch's metadata, and the last-committed pointer.
             StateMetadata::set_state_root(wb, &new_root);
             StoredBatchMetadata::set(wb, self.checkpoint.index(), self.checkpoint.metadata());
             StateMetadata::set_last_committed(wb, &self.checkpoint);
@@ -373,6 +343,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         }
     }
 
+    /// Marks the batch committed, updates shared state, and queues its resources for eviction.
     pub(crate) fn commit_done(self) {
         if !self.canceled() {
             // Eagerly update last_committed in the shared state.
@@ -392,6 +363,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
 }
 
 impl<S: Store, P: Processor<S>> Batch<ManagerTask<S, P>> for ScheduledBatch<S, P> {
+    /// Steals a ready transaction task for the worker, or None if the queue is empty.
     fn steal_available_tasks(
         &self,
         worker: &Worker<ManagerTask<S, P>>,
@@ -405,6 +377,8 @@ impl<S: Store, P: Processor<S>> Batch<ManagerTask<S, P>> for ScheduledBatch<S, P
         }
     }
 
+    /// Returns true when no transactions are pending or available.
+    #[inline(always)]
     fn is_depleted(&self) -> bool {
         self.num_pending() == 0 && self.available_txs.is_empty()
     }

--- a/scheduling/scheduler/src/state_diff.rs
+++ b/scheduling/scheduler/src/state_diff.rs
@@ -31,36 +31,36 @@ pub struct StateDiff<S: Store, P: Processor<S>> {
 
 impl<S: Store, P: Processor<S>> StateDiff<S, P> {
     /// Returns the resource ID this state diff tracks.
+    #[inline(always)]
     pub fn resource_id(&self) -> &ResourceId {
         &self.resource_id
     }
 
-    /// Returns the resource state as it was before this batch executed.
-    ///
-    /// # Panics
-    /// Panics if called before the read state has been resolved.
+    /// Returns the resource state before this batch executed; panics if not yet resolved.
+    #[inline(always)]
     pub fn read_state(&self) -> Arc<StateVersion> {
         self.read_state.load_full().expect("read state unknown")
     }
 
-    /// Returns the resource state after this batch executed.
-    ///
-    /// # Panics
-    /// Panics if called before the written state has been resolved.
+    /// Returns the resource state after this batch executed; panics if not yet resolved.
+    #[inline(always)]
     pub fn written_state(&self) -> Arc<StateVersion> {
         self.written_state.load_full().expect("written state unknown")
     }
 
     /// Returns the per-batch resource index.
+    #[inline(always)]
     pub fn index(&self) -> u32 {
         self.index
     }
 
     /// Returns `true` when the batch's execution advanced this resource's version.
+    #[inline(always)]
     pub fn data_updated(&self) -> bool {
         self.written_state().version() > self.read_state().version()
     }
 
+    /// Creates a state diff for a resource at its index within the batch.
     pub(crate) fn new(batch: ScheduledBatchRef<S, P>, resource_id: ResourceId, index: u32) -> Self {
         Self(Arc::new(StateDiffData {
             batch,
@@ -71,18 +71,13 @@ impl<S: Store, P: Processor<S>> StateDiff<S, P> {
         }))
     }
 
-    /// Returns true if the batch this state diff belongs to has been committed.
-    ///
-    /// If the batch reference can no longer be upgraded (batch dropped), returns true as the batch
-    /// has completed its lifecycle.
-    pub(crate) fn committed(&self) -> bool {
-        self.batch.upgrade().is_none_or(|batch| batch.committed())
-    }
-
+    /// Records the resource state read before execution.
+    #[inline(always)]
     pub(crate) fn set_read_state(&self, state: Arc<StateVersion>) {
         self.read_state.store(Some(state))
     }
 
+    /// Records the post-execution state and submits the diff to be persisted.
     pub(crate) fn set_written_state(&self, state: Arc<StateVersion>) {
         self.written_state.store(Some(state));
         if let Some(batch) = self.batch.upgrade() {
@@ -90,7 +85,9 @@ impl<S: Store, P: Processor<S>> StateDiff<S, P> {
         }
     }
 
+    /// Persists the new version and rollback pointer if the resource's version advanced.
     pub(crate) fn write<W: WriteBatch>(&self, wb: &mut W) {
+        // The batch and both states must be resolved by the time the worker writes this diff.
         let Some(batch) = self.batch.upgrade() else {
             panic!("batch must be known at write time");
         };
@@ -101,20 +98,22 @@ impl<S: Store, P: Processor<S>> StateDiff<S, P> {
             panic!("written_state must be known at write time");
         };
 
+        // Persist the new version and rollback pointer unless canceled or unchanged.
         if !batch.canceled() && written_state.version() > read_state.version() {
             written_state.write_data(wb);
             read_state.write_rollback_ptr(wb, batch.checkpoint().index());
         }
     }
 
-    pub(crate) fn write_done(self) {
-        if let Some(batch) = self.batch.upgrade() {
-            batch.decrease_pending_writes();
-        }
+    /// Returns true if the diff's batch has committed, or was dropped (lifecycle complete).
+    #[inline(always)]
+    pub(crate) fn committed(&self) -> bool {
+        self.batch.upgrade().is_none_or(|batch| batch.committed())
     }
 }
 
 impl<S: Store, P: Processor<S>> From<&StateDiff<S, P>> for Commitment {
+    /// Hashes the diff's written data into the resource's SMT commitment.
     fn from(diff: &StateDiff<S, P>) -> Self {
         let written_state = diff.written_state();
 

--- a/scheduling/scheduler/src/storage_cmd.rs
+++ b/scheduling/scheduler/src/storage_cmd.rs
@@ -10,6 +10,7 @@ pub enum Read<S: Store, P: Processor<S>> {
 }
 
 impl<S: Store, P: Processor<S>> ReadCmd for Read<S, P> {
+    /// Runs the variant's read against the store.
     fn exec<RS: ReadStore>(&self, store: &RS) {
         match self {
             Read::LatestData(resource_access) => resource_access.read_latest_data(store),
@@ -17,7 +18,7 @@ impl<S: Store, P: Processor<S>> ReadCmd for Read<S, P> {
     }
 }
 
-/// Commands dispatched to the storage manager's write worker.
+/// Commands dispatched to the storage managers write worker.
 pub enum Write<S: Store, P: Processor<S>> {
     /// Persist a resource's versioned data and rollback pointer.
     StateDiff(StateDiff<S, P>),
@@ -28,6 +29,7 @@ pub enum Write<S: Store, P: Processor<S>> {
 }
 
 impl<S: Store, P: Processor<S>> WriteCmd for Write<S, P> {
+    /// Applies the variant's write to the batch and returns it.
     fn exec<ST: Store>(&self, store: &ST, mut wb: ST::WriteBatch) -> ST::WriteBatch {
         match self {
             Write::StateDiff(state_diff) => state_diff.write(&mut wb),
@@ -37,11 +39,18 @@ impl<S: Store, P: Processor<S>> WriteCmd for Write<S, P> {
         wb
     }
 
-    fn done(self) {
+    /// Whole-batch commands (commit, rollback) flush immediately; diffs accumulate.
+    #[inline(always)]
+    fn flush_now(&self) -> bool {
+        matches!(self, Write::CommitBatch(_) | Write::Rollback(_))
+    }
+
+    /// Runs the variant's post-commit callback once its batch is flushed.
+    fn flushed(self) {
         match self {
-            Write::StateDiff(state_diff) => state_diff.write_done(),
             Write::CommitBatch(batch) => batch.commit_done(),
             Write::Rollback(rollback) => rollback.done(),
+            _ => {}
         }
     }
 }

--- a/storage/manager/src/manager.rs
+++ b/storage/manager/src/manager.rs
@@ -8,15 +8,21 @@ use vprogs_storage_types::Store;
 
 use crate::{ReadCmd, StorageConfig, WriteCmd, read::ReadManager, write::WriteManager};
 
+/// Coordinates the read and write workers over a shared store.
 #[smart_pointer]
 pub struct StorageManager<S: Store, R: ReadCmd, W: WriteCmd> {
+    /// Backing store, shared with both workers.
     store: Arc<S>,
+    /// Read worker for read commands.
     reader: ReadManager<S, R>,
-    writer: WriteManager<S, W>,
+    /// Write worker for write commands.
+    writer: WriteManager<W>,
+    /// Set on shutdown to stop both workers.
     is_shutdown: Arc<AtomicBool>,
 }
 
 impl<S: Store, R: ReadCmd, W: WriteCmd> StorageManager<S, R, W> {
+    /// Opens the store and spawns the read and write workers.
     pub fn new(config: StorageConfig<S>) -> Self {
         let store = Arc::new(config.store.expect("StorageConfig requires a store"));
         let is_shutdown = Arc::new(AtomicBool::new(false));
@@ -29,21 +35,28 @@ impl<S: Store, R: ReadCmd, W: WriteCmd> StorageManager<S, R, W> {
         }))
     }
 
+    /// Queues a read command for the read worker.
+    #[inline(always)]
     pub fn submit_read(&self, cmd: R) {
         self.reader.submit(cmd);
     }
 
+    /// Queues a write command for the write worker.
+    #[inline(always)]
     pub fn submit_write(&self, cmd: W) {
         self.writer.submit(cmd);
     }
 
+    /// Returns the backing store.
+    #[inline(always)]
     pub fn store(&self) -> &Arc<S> {
         &self.store
     }
 
+    /// Signals shutdown and waits for both workers to finish.
     pub fn shutdown(&self) {
+        // Flag shutdown before waking the workers so their loops observe it and exit.
         self.is_shutdown.store(true, Ordering::Release);
-
         self.reader.shutdown();
         self.writer.shutdown();
     }

--- a/storage/manager/src/utils/cmd_queue.rs
+++ b/storage/manager/src/utils/cmd_queue.rs
@@ -7,13 +7,17 @@ use crossbeam_queue::SegQueue;
 use crossbeam_utils::CachePadded;
 use vprogs_core_macros::smart_pointer;
 
+/// A lock-free queue that tracks an approximate length.
 #[smart_pointer]
 pub struct CmdQueue<T> {
+    /// The underlying lock-free queue.
     queue: SegQueue<T>,
+    /// Upper-bound length: bumped before push, decremented after pop.
     approx_len: CachePadded<AtomicUsize>,
 }
 
 impl<T> CmdQueue<T> {
+    /// Creates an empty queue.
     pub fn new() -> Self {
         Self(Arc::new(CmdQueueData {
             queue: SegQueue::new(),
@@ -21,13 +25,15 @@ impl<T> CmdQueue<T> {
         }))
     }
 
+    /// Pushes a job and returns the new approximate length.
     pub fn push(&self, job: T) -> usize {
-        // bump len before pushing so that pop doesn't underflow
-        let approx_new_len = self.approx_len.fetch_add(1, Ordering::Relaxed) + 1;
+        // Bump len before pushing so that pop doesn't underflow.
+        let approx_new_len = self.approx_len.fetch_add(1, Ordering::SeqCst) + 1;
         self.queue.push(job);
         approx_new_len
     }
 
+    /// Pops a job if available, returning it with the resulting approximate length.
     pub fn pop(&self) -> (Option<T>, usize) {
         match self.queue.pop() {
             None => (None, self.approx_len()),
@@ -35,13 +41,15 @@ impl<T> CmdQueue<T> {
         }
     }
 
+    /// Returns the approximate number of queued jobs.
     #[inline(always)]
     pub fn approx_len(&self) -> usize {
         self.approx_len.load(Ordering::Relaxed)
     }
 
+    /// Returns true if the queue is empty.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
-        self.queue.is_empty()
+        self.approx_len.load(Ordering::SeqCst) == 0
     }
 }

--- a/storage/manager/src/utils/worker_handle.rs
+++ b/storage/manager/src/utils/worker_handle.rs
@@ -8,13 +8,18 @@ use std::{
 
 use crossbeam_utils::{CachePadded, atomic::AtomicCell, sync::Unparker};
 
+/// Handle to wake and join the worker thread.
 pub struct WorkerHandle {
+    /// Wakes the parked worker.
     unparker: Unparker,
+    /// Shared parked flag; lets a producer decide whether to wake.
     is_parked: Arc<CachePadded<AtomicBool>>,
+    /// Worker thread's join handle, taken once on shutdown.
     join_handle: AtomicCell<Option<JoinHandle<()>>>,
 }
 
 impl WorkerHandle {
+    /// Builds the handle from the worker's wake controls and join handle.
     pub(crate) fn new(
         unparker: Unparker,
         is_parked: Arc<CachePadded<AtomicBool>>,
@@ -23,16 +28,19 @@ impl WorkerHandle {
         Self { unparker, is_parked, join_handle: AtomicCell::new(Some(join_handle)) }
     }
 
-    #[inline]
+    /// Returns whether the worker is parked.
+    #[inline(always)]
     pub(crate) fn is_parked(&self) -> bool {
-        self.is_parked.load(Ordering::Relaxed)
+        self.is_parked.load(Ordering::SeqCst)
     }
 
-    #[inline]
+    /// Wakes the worker thread.
+    #[inline(always)]
     pub(crate) fn wake(&self) {
         self.unparker.unpark();
     }
 
+    /// Takes the join handle so the thread can be joined once.
     pub(crate) fn take_join(&self) -> Option<JoinHandle<()>> {
         self.join_handle.take()
     }

--- a/storage/manager/src/write/cmd.rs
+++ b/storage/manager/src/write/cmd.rs
@@ -1,7 +1,13 @@
 use vprogs_storage_types::Store;
 
+/// A command the write worker applies to an accumulating write batch.
 pub trait WriteCmd: Send + Sync + 'static {
+    /// Applies the command to the batch and returns the batch to continue with.
     fn exec<S: Store>(&self, store: &S, batch: S::WriteBatch) -> S::WriteBatch;
 
-    fn done(self);
+    /// Whether the worker must flush immediately after this command instead of batching it.
+    fn flush_now(&self) -> bool;
+
+    /// Called once the command's batch has been committed.
+    fn flushed(self);
 }

--- a/storage/manager/src/write/manager.rs
+++ b/storage/manager/src/write/manager.rs
@@ -1,7 +1,4 @@
-use std::{
-    marker::PhantomData,
-    sync::{Arc, atomic::AtomicBool},
-};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use vprogs_storage_types::Store;
 
@@ -11,33 +8,42 @@ use crate::{
     write::{WriteConfig, WriteWorker},
 };
 
-pub struct WriteManager<K: Store, W: WriteCmd> {
+/// Queues write commands for the background worker and wakes it when needed.
+pub struct WriteManager<W: WriteCmd> {
+    /// Batching thresholds, also held by the worker.
     config: WriteConfig,
+    /// Command queue shared with the worker.
     queue: CmdQueue<W>,
+    /// Handle to wake and join the worker thread.
     worker: WorkerHandle,
-    _marker: PhantomData<K>,
 }
 
-impl<K: Store, W: WriteCmd> WriteManager<K, W> {
-    pub fn new(config: WriteConfig, store: &Arc<K>, is_shutdown: &Arc<AtomicBool>) -> Self {
+impl<W: WriteCmd> WriteManager<W> {
+    /// Creates the queue, spawns the worker, and returns the manager.
+    pub fn new<K: Store>(
+        config: WriteConfig,
+        store: &Arc<K>,
+        is_shutdown: &Arc<AtomicBool>,
+    ) -> Self {
         let queue = CmdQueue::new();
-        Self {
-            worker: WriteWorker::spawn(&config, &queue, store, is_shutdown),
-            queue,
-            config,
-            _marker: PhantomData,
-        }
+        Self { worker: WriteWorker::spawn(&config, &queue, store, is_shutdown), queue, config }
     }
 
+    /// Queues a write and wakes a parked worker when it must act on it now.
     pub fn submit(&self, write: W) {
-        if self.queue.push(write) >= self.config.batch_size && self.worker.is_parked() {
+        // Push the write, capturing its flush-now flag and the resulting queue depth.
+        let flush_now = write.flush_now();
+        let queue_len = self.queue.push(write);
+
+        // Wake a parked worker on a flush-now write or a full batch.
+        if (flush_now || queue_len >= self.config.batch_size) && self.worker.is_parked() {
             self.worker.wake();
         }
     }
 
+    /// Wakes the worker and blocks until its thread finishes.
     pub fn shutdown(&self) {
         self.worker.wake();
-
         if let Some(handle) = self.worker.take_join() {
             handle.join().expect("write worker panicked");
         }

--- a/storage/manager/src/write/worker.rs
+++ b/storage/manager/src/write/worker.rs
@@ -16,22 +16,31 @@ use crate::{
     write::WriteConfig,
 };
 
+/// Background thread that drains the write queue and commits accumulated batches to the store.
 pub struct WriteWorker<K: Store, W: WriteCmd> {
+    /// Size and age thresholds that decide when a batch is flushed.
     config: WriteConfig,
+    /// Store the batches are committed to.
     store: Arc<K>,
+    /// Pending write commands, shared with the manager that feeds them.
     queue: CmdQueue<W>,
+    /// True while the worker is parked, so a producer knows whether to wake it.
     is_parked: Arc<CachePadded<AtomicBool>>,
+    /// Blocks the thread while idle; signalled to wake it.
     parker: Parker,
+    /// Set on shutdown to break the run loop.
     is_shutdown: Arc<AtomicBool>,
 }
 
 impl<K: Store, W: WriteCmd> WriteWorker<K, W> {
+    /// Spawns the worker thread and returns a handle to wake and join it.
     pub(crate) fn spawn(
         config: &WriteConfig,
         queue: &CmdQueue<W>,
         store: &Arc<K>,
         is_shutdown: &Arc<AtomicBool>,
     ) -> WorkerHandle {
+        // Build the worker from the shared handles, with its own parker and parked flag.
         let this = Self {
             config: config.clone(),
             queue: queue.clone(),
@@ -41,6 +50,7 @@ impl<K: Store, W: WriteCmd> WriteWorker<K, W> {
             is_parked: Arc::new(CachePadded::new(AtomicBool::new(false))),
         };
 
+        // Spawn the run loop; the returned handle shares its unparker and parked flag to wake it.
         WorkerHandle::new(
             this.parker.unparker().clone(),
             this.is_parked.clone(),
@@ -48,49 +58,68 @@ impl<K: Store, W: WriteCmd> WriteWorker<K, W> {
         )
     }
 
+    /// Drains the queue into batches, flushing on a flush-now command or a full or aged batch.
     fn run(self) {
+        // Accumulate commands into a batch and track its age for the flush backstop.
         let mut batch_cmds = Vec::with_capacity(self.config.batch_size);
         let mut write_batch = self.store.write_batch();
         let mut created = Instant::now();
 
         while !self.is_shutdown() {
-            if !batch_cmds.is_empty() && self.should_commit(batch_cmds.len(), created) {
-                self.store.commit(write_batch);
-                batch_cmds.drain(..).for_each(W::done);
-
-                write_batch = self.store.write_batch();
-                created = Instant::now();
+            // Flush a full or aged batch even without an explicit flush command.
+            if !batch_cmds.is_empty() && self.should_flush(batch_cmds.len(), created) {
+                (write_batch, created) = self.flush(write_batch, &mut batch_cmds);
             }
 
+            // Process the next command in order.
             match self.queue.pop() {
                 (Some(cmd), _) => {
+                    // Capture the commands flush-now flag and execute it against the write batch.
+                    let flush_now = cmd.flush_now();
                     write_batch = cmd.exec(&*self.store, write_batch);
                     batch_cmds.push(cmd);
+
+                    // Flush the batch immediately if the command requested it.
+                    if flush_now {
+                        (write_batch, created) = self.flush(write_batch, &mut batch_cmds);
+                    }
                 }
                 _ => self.park(),
             }
         }
     }
 
-    fn should_commit(&self, batch_size: usize, created: Instant) -> bool {
-        self.batch_is_full(batch_size) || created.elapsed() >= self.config.batch_duration
-    }
-
-    #[inline(always)]
-    fn batch_is_full(&self, batch_size: usize) -> bool {
-        batch_size >= self.config.batch_size
-    }
-
+    /// Returns whether shutdown has been signalled.
     #[inline(always)]
     fn is_shutdown(&self) -> bool {
         self.is_shutdown.load(Ordering::Acquire)
     }
 
+    /// Returns whether the batch is full or has outlived the flush window.
+    #[inline(always)]
+    fn should_flush(&self, batch_size: usize, created: Instant) -> bool {
+        self.batch_is_full(batch_size) || created.elapsed() >= self.config.batch_duration
+    }
+
+    /// Returns whether the batch has reached the configured size.
+    #[inline(always)]
+    fn batch_is_full(&self, batch_size: usize) -> bool {
+        batch_size >= self.config.batch_size
+    }
+
+    /// Commits the batch, runs each command's flushed callback, and returns a fresh batch.
+    fn flush(&self, write_batch: K::WriteBatch, cmds: &mut Vec<W>) -> (K::WriteBatch, Instant) {
+        self.store.commit(write_batch);
+        cmds.drain(..).for_each(W::flushed);
+        (self.store.write_batch(), Instant::now())
+    }
+
+    /// Parks until woken or the batch window elapses, unless the queue is already non-empty.
     fn park(&self) {
-        self.is_parked.store(true, Ordering::Relaxed);
+        self.is_parked.store(true, Ordering::SeqCst);
         if !self.is_shutdown() && self.queue.is_empty() {
             self.parker.park_timeout(self.config.batch_duration);
         }
-        self.is_parked.store(false, Ordering::Relaxed);
+        self.is_parked.store(false, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
## Summary

With the default `batch_duration` of 10ms, the write worker only committed a batch when
it filled or that timer elapsed, so every commit waited out the window. The scheduler
lifecycle also blocked on each commit before submitting the next, which capped
throughput at about 100 batches per second.

This branch makes durability-bearing commands flush on demand, wakes a parked worker the
moment such work arrives, and removes two redundant wait points so the lifecycle
pipelines. Throughput is now bound only by execution and the per-commit flush rather
than a fixed timer; an empty-batch benchmark on the test machine went from about **100** to
about **12,000** batches per second (roughly 120x).

## Changes

Write worker and submit path:

- `WriteCmd::flush_now` is a new flag marking commands that must hit disk immediately
  (commit, rollback). The worker flushes right after them, while plain state diffs still
  accumulate.
- `submit` wakes a parked worker as soon as a `flush_now` command or a full batch
  arrives, instead of waiting out the timer.
- The submit/park wake handshake is made store-buffer safe: the parked flag and the
  queue length are both accessed with `SeqCst`, so a push can never race a park into a
  lost wakeup.
- `WriteCmd::flushed` (was `done`) is the post-commit callback.

Lifecycle:

- Removed the `persisted` latch and the wait for persistence. Under the
  eventual-consistency model the hand-off to the storage manager is the persistence
  point (there is no fsync or WAL-flush boundary), so the lifecycle does not wait for
  the write to land.
- Removed `wait_committed` from the batch lifecycle worker, so commits pipeline through
  the write worker. Durability is still observable through the `committed` latch. The
  SMT read-after-write order is preserved by `flush_now`, which flushes each commit
  before the next one reads the prior tree from disk.

Cleanup:

- `WriteManager` drops a phantom store-type parameter (only `new` ever needed it).
- Doc comments, `inline(always)` on the small accessors, and use-order method layout
  across the write path and the scheduler lifecycle, diff, and batch types.

## Notes

- Correctness rests on `flush_now` serializing consecutive commits for the SMT, and on
  the per-batch cancel checks (not the removed latches) guarding rollback and
  read-after-write.
