### PR TITLE
Feat: Resume committed batches on reorg-back

### DIFF
--- a/scheduling/scheduler/src/processor.rs
+++ b/scheduling/scheduler/src/processor.rs
@@ -34,6 +34,11 @@ pub trait Processor<S: Store>: Clone + Sized + Send + Sync + 'static {
     /// Program identifier keying an aggregate (settlement) receipt in the proof-receipt store.
     fn aggregator_image_id(&self) -> [u8; 32];
 
+    /// Whether a returning committed batch may be restored from disk instead of re-executed.
+    fn supports_restore(&self) -> bool {
+        false
+    }
+
     /// The transaction payload type (e.g. kaspa `L1Transaction`, `usize` in tests).
     /// The scheduler wraps it in `SchedulerTransaction<Self::Transaction>`.
     type Transaction: Send + Sync + 'static;

--- a/scheduling/scheduler/src/resource_access.rs
+++ b/scheduling/scheduler/src/resource_access.rs
@@ -6,6 +6,7 @@ use std::sync::{
 use arc_swap::ArcSwapOption;
 use vprogs_core_macros::smart_pointer;
 use vprogs_core_types::{AccessMetadata, AccessType};
+use vprogs_state_ptr_rollback::StatePtrRollback;
 use vprogs_state_version::StateVersion;
 use vprogs_storage_manager::StorageManager;
 use vprogs_storage_types::{ReadStore, Store};
@@ -112,6 +113,30 @@ impl<S: Store, P: Processor<S>> ResourceAccess<S, P> {
             store,
             self.access_metadata.resource_id,
         )));
+    }
+
+    /// Restores this access's state from the committed batch on disk, without executing.
+    pub(crate) fn restore_committed_data<R: ReadStore>(&self, store: &R, batch_index: u64) {
+        // The rollback pointer's presence distinguishes a written resource from read-only.
+        let resource_id = self.access_metadata.resource_id;
+        let (read, written) = match StatePtrRollback::get(store, batch_index, &resource_id) {
+            // Written: the old version is the read, this batch's version is the written.
+            Some(old_version) => (
+                StateVersion::at_version(store, old_version, resource_id),
+                StateVersion::at_version(store, batch_index, resource_id),
+            ),
+            // Read-only: unchanged, so both stay at the current latest.
+            None => {
+                let current = StateVersion::from_latest_data(store, resource_id);
+                (current.clone(), current)
+            }
+        };
+
+        // Read resolves the diff directly; on the access it would trigger execution.
+        self.state_diff.set_read_state(Arc::new(read));
+
+        // Written goes on the access, which forwards the value to the next batch.
+        self.set_written_state(Arc::new(written));
     }
 
     pub(crate) fn tx(&self) -> &ScheduledTransactionRef<S, P> {

--- a/scheduling/scheduler/src/rollback.rs
+++ b/scheduling/scheduler/src/rollback.rs
@@ -87,9 +87,6 @@ impl<S: Store, P: Processor<S>> Rollback<S, P> {
             if rollback_to_genesis {
                 StateMetadata::set_root(wb, &self.target);
             }
-
-            // Reset the persisted state root to the target version's (canonical) root.
-            StateMetadata::set_state_root(wb, &store.root(self.target.index()));
         }));
 
         // Return a new empty write batch for further operations.

--- a/scheduling/scheduler/src/scheduled_batch.rs
+++ b/scheduling/scheduler/src/scheduled_batch.rs
@@ -446,16 +446,17 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                 state_diff.written_state().write_latest_ptr(wb);
             }
 
-            // Update the authenticated state tree with all resource state diffs from this batch.
-            let new_root = store.update(
-                wb,
-                updated.into_iter().map(Commitment::from).collect(),
-                self.checkpoint.index(),
-            );
+            // A fresh batch updates the SMT and persists its metadata.
+            if !self.restored {
+                StoredBatchMetadata::set(wb, self.checkpoint.index(), self.checkpoint.metadata());
+                store.update(
+                    wb,
+                    updated.into_iter().map(Commitment::from).collect(),
+                    self.checkpoint.index(),
+                );
+            }
 
-            // Record the new state root, this batch's metadata, and the last-committed pointer.
-            StateMetadata::set_state_root(wb, &new_root);
-            StoredBatchMetadata::set(wb, self.checkpoint.index(), self.checkpoint.metadata());
+            // Record the last-committed pointer.
             StateMetadata::set_last_committed(wb, &self.checkpoint);
 
             // Persist root on first commit for crash-fault tolerance. Root was already set

--- a/scheduling/scheduler/src/scheduled_batch.rs
+++ b/scheduling/scheduler/src/scheduled_batch.rs
@@ -49,6 +49,8 @@ pub struct ScheduledBatch<S: Store, P: Processor<S>> {
     state: SchedulerState<S, P>,
     /// This batch's sequential index and metadata.
     checkpoint: Checkpoint<P::BatchMetadata>,
+    /// True if restored from committed disk state rather than executed.
+    restored: bool,
     /// All transactions in this batch.
     txs: Vec<ScheduledTransaction<S, P>>,
     /// One state diff per unique resource accessed by this batch.
@@ -121,6 +123,12 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
     #[inline(always)]
     pub fn canceled(&self) -> bool {
         self.checkpoint.index() > self.cancellation.threshold()
+    }
+
+    /// Returns true if this batch was restored from committed disk state rather than executed.
+    #[inline(always)]
+    pub fn restored(&self) -> bool {
+        self.restored
     }
 
     /// Returns true if all transactions have been executed.
@@ -314,6 +322,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
         scheduler: &mut Scheduler<S, P>,
         txs: Vec<SchedulerTransaction<P::Transaction>>,
         checkpoint: Checkpoint<P::BatchMetadata>,
+        restored: bool,
     ) -> Self {
         Self(Arc::new_cyclic(|this| {
             let processed = AtomicAsyncLatch::default();
@@ -335,6 +344,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                 processor: scheduler.processor().clone(),
                 state: scheduler.state().clone(),
                 checkpoint,
+                restored,
                 pending_txs: AtomicU64::new(txs.len() as u64),
                 pending_tx_artifacts: AtomicU64::new(txs.len() as u64),
                 txs: txs
@@ -391,10 +401,7 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
 
         // Nothing executed, so drive the counters down and open the done-latches directly.
         self.pending_txs.store(0, Ordering::Release);
-        self.pending_tx_artifacts.store(0, Ordering::Release);
         self.processed.open();
-        self.tx_artifacts_published.open();
-        self.artifact_published.open();
     }
 
     /// Pushes a transaction onto the work-stealing queue of ready transactions.

--- a/scheduling/scheduler/src/scheduled_batch.rs
+++ b/scheduling/scheduler/src/scheduled_batch.rs
@@ -13,7 +13,7 @@ use vprogs_scheduling_execution_workers::Batch;
 use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_state_proof_receipt::{AggregatorKey, BatchKey, Prefix};
-use vprogs_storage_types::Store;
+use vprogs_storage_types::{ReadStore, Store};
 
 use crate::{
     CancellationContext, Read, ReadReceipt, ReceiptRead, ScheduledTransaction, Scheduler,
@@ -375,6 +375,26 @@ impl<S: Store, P: Processor<S>> ScheduledBatch<S, P> {
                 }
             }
         }
+    }
+
+    /// Restores the committed batch from disk and marks it done, skipping execution.
+    pub(crate) fn restore_committed<RS: ReadStore>(&self, store: &RS) {
+        // Each resource's tail access holds the batch's final state; restore it from disk.
+        let index = self.checkpoint.index();
+        for tx in self.txs() {
+            for access in tx.resources() {
+                if access.is_batch_tail() {
+                    access.restore_committed_data(store, index);
+                }
+            }
+        }
+
+        // Nothing executed, so drive the counters down and open the done-latches directly.
+        self.pending_txs.store(0, Ordering::Release);
+        self.pending_tx_artifacts.store(0, Ordering::Release);
+        self.processed.open();
+        self.tx_artifacts_published.open();
+        self.artifact_published.open();
     }
 
     /// Pushes a transaction onto the work-stealing queue of ready transactions.

--- a/scheduling/scheduler/src/scheduler.rs
+++ b/scheduling/scheduler/src/scheduler.rs
@@ -11,11 +11,11 @@ use vprogs_storage_canonical_chain::CanonicalChainManager;
 use vprogs_storage_manager::StorageConfig;
 use vprogs_storage_types::Store;
 
-use crate::{cpu_task::ManagerTask, processor::Processor,
-            rollback::Rollback, state::SchedulerState,
-            BatchLifecycleWorker, CancellationContext, ExecutionConfig, PruningWorker, Read, Resource,
-            ResourceAccess, ScheduledBatch, ScheduledBatchRef, ScheduledTransactionRef, SchedulerError,
-            SchedulerResult, StateDiff, Write,
+use crate::{
+    BatchLifecycleWorker, CancellationContext, ExecutionConfig, PruningWorker, Read, Resource,
+    ResourceAccess, ScheduledBatch, ScheduledBatchRef, ScheduledTransactionRef, SchedulerError,
+    SchedulerResult, StateDiff, Write, cpu_task::ManagerTask, processor::Processor,
+    rollback::Rollback, state::SchedulerState,
 };
 
 /// Orchestrates transaction execution, state management, and storage coordination.

--- a/scheduling/scheduler/src/scheduler.rs
+++ b/scheduling/scheduler/src/scheduler.rs
@@ -74,8 +74,7 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
         txs: Vec<SchedulerTransaction<P::Transaction>>,
     ) -> ScheduledBatch<S, P> {
         let (checkpoint, restore) = self.next_checkpoint(metadata);
-
-        ScheduledBatch::new(self, txs, checkpoint).tap(|batch| {
+        ScheduledBatch::new(self, txs, checkpoint, restore).tap(|batch| {
             // Notify the processor, allowing it to initialize internal caches or buffers.
             self.processor.on_batch_scheduled(batch);
 
@@ -83,7 +82,7 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
             self.batch_lifecycle_worker.push(batch.clone());
 
             // Restore a returning committed batch from disk, or connect and execute a new one.
-            if restore {
+            if batch.restored() {
                 self.state.storage().submit_read(Read::CommittedBatch(batch.clone()));
             } else {
                 batch.connect();
@@ -253,11 +252,10 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
             self.state.set_root(Arc::new(checkpoint.clone()));
         }
 
-        // A returning id restores if its state is already on disk.
-        let restore = match outcome.is_new {
-            true => false,
-            false => StoredBatchMetadata::exists(&**self.state.storage().store(), outcome.id),
-        };
+        // A returning id restores if the processor opts in and its state is already on disk.
+        let restore = !outcome.is_new
+            && self.processor.supports_restore()
+            && StoredBatchMetadata::exists(&**self.state.storage().store(), outcome.id);
 
         (checkpoint, restore)
     }

--- a/scheduling/scheduler/src/scheduler.rs
+++ b/scheduling/scheduler/src/scheduler.rs
@@ -11,11 +11,11 @@ use vprogs_storage_canonical_chain::CanonicalChainManager;
 use vprogs_storage_manager::StorageConfig;
 use vprogs_storage_types::Store;
 
-use crate::{
-    BatchLifecycleWorker, CancellationContext, ExecutionConfig, PruningWorker, Resource,
-    ResourceAccess, ScheduledBatch, ScheduledBatchRef, ScheduledTransactionRef, SchedulerError,
-    SchedulerResult, StateDiff, Write, cpu_task::ManagerTask, processor::Processor,
-    rollback::Rollback, state::SchedulerState,
+use crate::{cpu_task::ManagerTask, processor::Processor,
+            rollback::Rollback, state::SchedulerState,
+            BatchLifecycleWorker, CancellationContext, ExecutionConfig, PruningWorker, Read, Resource,
+            ResourceAccess, ScheduledBatch, ScheduledBatchRef, ScheduledTransactionRef, SchedulerError,
+            SchedulerResult, StateDiff, Write,
 };
 
 /// Orchestrates transaction execution, state management, and storage coordination.
@@ -73,24 +73,26 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
         metadata: P::BatchMetadata,
         txs: Vec<SchedulerTransaction<P::Transaction>>,
     ) -> ScheduledBatch<S, P> {
-        let checkpoint = self.next_checkpoint(metadata);
+        let (checkpoint, restore) = self.next_checkpoint(metadata);
 
-        ScheduledBatch::new(self, txs, checkpoint)
-            // Connect transactions to resource dependency chains.
-            .tap(ScheduledBatch::connect)
-            .tap(|batch| {
-                // Notify the processor, allowing it to initialize internal caches or buffers.
-                self.processor.on_batch_scheduled(batch);
+        ScheduledBatch::new(self, txs, checkpoint).tap(|batch| {
+            // Notify the processor, allowing it to initialize internal caches or buffers.
+            self.processor.on_batch_scheduled(batch);
 
-                // Push to the batch lifecycle worker for lifecycle progression.
-                self.batch_lifecycle_worker.push(batch.clone());
+            // Push to the batch lifecycle worker for lifecycle progression.
+            self.batch_lifecycle_worker.push(batch.clone());
 
-                // Submit to execution workers for parallel processing.
+            // Restore a returning committed batch from disk, or connect and execute a new one.
+            if restore {
+                self.state.storage().submit_read(Read::CommittedBatch(batch.clone()));
+            } else {
+                batch.connect();
                 self.execution_workers.execute(batch.clone());
+            }
 
-                // Process the eviction queue; this batch's resources won't be evicted yet.
-                self.process_eviction_queue()
-            })
+            // Process the eviction queue; this batch's resources won't be evicted yet.
+            self.process_eviction_queue();
+        })
     }
 
     /// Processes pending eviction requests from committed batches.
@@ -233,12 +235,15 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
             .collect()
     }
 
-    /// Advances to the next batch, returning its checkpoint.
-    fn next_checkpoint(&mut self, metadata: P::BatchMetadata) -> Checkpoint<P::BatchMetadata> {
+    /// Advances to the next batch, returning its checkpoint and whether it can be restored.
+    fn next_checkpoint(
+        &mut self,
+        metadata: P::BatchMetadata,
+    ) -> (Checkpoint<P::BatchMetadata>, bool) {
         self.drain_committed();
 
-        let index = self.canonical_chain_manager.append(metadata.clone()).id;
-        let checkpoint = Checkpoint::new(index, metadata);
+        let outcome = self.canonical_chain_manager.append(metadata.clone());
+        let checkpoint = Checkpoint::new(outcome.id, metadata);
         self.state.set_last_processed(Arc::new(checkpoint.clone()));
         self.pending_batches.push_back(checkpoint.clone());
 
@@ -248,7 +253,13 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
             self.state.set_root(Arc::new(checkpoint.clone()));
         }
 
-        checkpoint
+        // A returning id restores if its state is already on disk.
+        let restore = match outcome.is_new {
+            true => false,
+            false => StoredBatchMetadata::exists(&**self.state.storage().store(), outcome.id),
+        };
+
+        (checkpoint, restore)
     }
 
     /// Cancels in-flight batches and rolls back shared state to the given index.
@@ -297,7 +308,8 @@ impl<S: Store, P: Processor<S>> Scheduler<S, P> {
         }
 
         // Fall back to disk for committed batches.
-        Checkpoint::new(index, StoredBatchMetadata::get(&**self.state.storage().store(), index))
+        let store = &**self.state.storage().store();
+        Checkpoint::new(index, StoredBatchMetadata::get(store, index))
     }
 }
 

--- a/scheduling/scheduler/src/state_diff.rs
+++ b/scheduling/scheduler/src/state_diff.rs
@@ -80,7 +80,7 @@ impl<S: Store, P: Processor<S>> StateDiff<S, P> {
     /// Records the post-execution state and submits the diff to be persisted.
     pub(crate) fn set_written_state(&self, state: Arc<StateVersion>) {
         self.written_state.store(Some(state));
-        if let Some(batch) = self.batch.upgrade() {
+        if let Some(batch) = self.batch.upgrade().filter(|batch| !batch.restored()) {
             batch.submit_write(Write::StateDiff(self.clone()));
         }
     }

--- a/scheduling/scheduler/src/storage_cmd.rs
+++ b/scheduling/scheduler/src/storage_cmd.rs
@@ -250,6 +250,8 @@ pub enum Read<S: Store, P: Processor<S>> {
     LatestData(ResourceAccess<S, P>),
     /// Look up a cached typed proof-receipt by key.
     ReadReceipt(ReadReceipt<S, P>),
+    /// Reconstruct a committed batch's state diffs from disk (restore after a reorg).
+    CommittedBatch(ScheduledBatch<S, P>),
 }
 
 impl<S: Store, P: Processor<S>> ReadCmd for Read<S, P> {
@@ -258,6 +260,7 @@ impl<S: Store, P: Processor<S>> ReadCmd for Read<S, P> {
         match self {
             Read::LatestData(resource_access) => resource_access.read_latest_data(store),
             Read::ReadReceipt(receipt) => receipt.read(store),
+            Read::CommittedBatch(batch) => batch.restore_committed(store),
         }
     }
 }

--- a/scheduling/scheduler/tests/e2e.rs
+++ b/scheduling/scheduler/tests/e2e.rs
@@ -2302,3 +2302,155 @@ pub fn test_finalize_past_orphan_bucket_keeps_predecessor() {
         scheduler.shutdown();
     }
 }
+
+/// Tests that re-appending a previously committed block after a reorg restores its state from disk
+/// rather than re-executing its transactions.
+#[test]
+pub fn test_restore_returning_committed_batch_skips_execution() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    {
+        let storage: RocksDbStore = RocksDbStore::open(temp_dir.path());
+        let mut scheduler = Scheduler::new(
+            ExecutionConfig::default().with_processor(Processor),
+            StorageConfig::default().with_store(storage),
+        );
+
+        // Commit block 1, writing value 100 to resource 1.
+        let batch1 = scheduler.schedule(
+            1,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                100,
+            )],
+        );
+        batch1.wait_committed_blocking();
+        scheduler.assert_written_state(ResourceId::for_test(1), vec![100]);
+
+        // Reorg block 1 away; its resource is reverted but its committed state stays retained on
+        // disk.
+        scheduler.rollback_to(0).expect("rollback should succeed");
+        scheduler.assert_resource_deleted(ResourceId::for_test(1));
+
+        // Re-append the same block (same metadata -> same block hash -> returning id). The provided
+        // transaction would write 999 if executed; restore must ignore it and reuse the committed
+        // 100.
+        let restored = scheduler.schedule(
+            1,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                999,
+            )],
+        );
+        restored.wait_committed_blocking();
+
+        assert_eq!(restored.checkpoint().index(), 1, "returning block keeps its original id");
+        scheduler.assert_written_state(ResourceId::for_test(1), vec![100]);
+
+        scheduler.shutdown();
+    }
+}
+
+/// Tests that a restored batch feeds its written state into a following batch's read through the
+/// in-memory resource chain, before the restore has committed to disk.
+#[test]
+pub fn test_restore_feeds_following_batch_chain() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    {
+        let storage: RocksDbStore = RocksDbStore::open(temp_dir.path());
+        let mut scheduler = Scheduler::new(
+            ExecutionConfig::default().with_processor(Processor),
+            StorageConfig::default().with_store(storage),
+        );
+
+        // Commit block 1, writing value 100 to resource 1, then reorg it away.
+        scheduler
+            .schedule(
+                1,
+                vec![SchedulerTransaction::new(
+                    0,
+                    vec![AccessMetadata::write(ResourceId::for_test(1))],
+                    100,
+                )],
+            )
+            .wait_committed_blocking();
+        scheduler.rollback_to(0).expect("rollback should succeed");
+
+        // Re-append block 1 to restore it, but do NOT wait: the following batch must chain off its
+        // restored written state in memory rather than reading committed disk state.
+        let _restored = scheduler.schedule(
+            1,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                999,
+            )],
+        );
+
+        // A following new block writes resource 1 again. It must read the restored value (100) and
+        // append 300 - not the post-rollback empty state, and not the ignored 999.
+        let following = scheduler.schedule(
+            2,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                300,
+            )],
+        );
+        following.wait_committed_blocking();
+
+        scheduler.assert_written_state(ResourceId::for_test(1), vec![100, 300]);
+
+        scheduler.shutdown();
+    }
+}
+
+/// Tests that committing a restored batch through the normal path re-runs `store.update`
+/// idempotently: the reconstructed SMT reproduces the original state root.
+#[test]
+pub fn test_restore_smt_root_is_idempotent() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    {
+        let storage: RocksDbStore = RocksDbStore::open(temp_dir.path());
+        let mut scheduler = Scheduler::new(
+            ExecutionConfig::default().with_processor(Processor),
+            StorageConfig::default().with_store(storage),
+        );
+
+        // Commit block 1 and capture the resulting state root.
+        let batch1 = scheduler.schedule(
+            1,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                100,
+            )],
+        );
+        batch1.wait_committed_blocking();
+        let root_before = StateMetadata::state_root(&**scheduler.state().storage().store());
+
+        // Reorg away, then restore the same block.
+        scheduler.rollback_to(0).expect("rollback should succeed");
+        let restored = scheduler.schedule(
+            1,
+            vec![SchedulerTransaction::new(
+                0,
+                vec![AccessMetadata::write(ResourceId::for_test(1))],
+                100,
+            )],
+        );
+        restored.wait_committed_blocking();
+
+        // The re-run store.update reproduces the same tree: same state root, same per-version root.
+        let store = scheduler.state().storage().store();
+        assert_eq!(
+            StateMetadata::state_root(&**store),
+            root_before,
+            "restored state root must match the original"
+        );
+        assert_eq!(store.root(1), root_before, "restored per-version root must match the original");
+
+        scheduler.shutdown();
+    }
+}

--- a/scheduling/scheduler/tests/e2e.rs
+++ b/scheduling/scheduler/tests/e2e.rs
@@ -13,6 +13,12 @@ use vprogs_storage_canonical_chain::BUCKET_CAPACITY;
 use vprogs_storage_manager::StorageConfig;
 use vprogs_storage_rocksdb_store::RocksDbStore;
 
+/// The current global state root: the SMT root at the last committed version.
+fn state_root(scheduler: &Scheduler<RocksDbStore, Processor>) -> [u8; 32] {
+    let store = scheduler.state().storage().store();
+    store.root(StateMetadata::last_committed::<u64, _>(store.as_ref()).index())
+}
+
 #[test]
 pub fn test_scheduler() {
     let temp_dir = TempDir::new().expect("failed to create temp dir");
@@ -1548,11 +1554,6 @@ pub fn test_smt_state_root_after_commits() {
             StorageConfig::default().with_store(storage),
         );
 
-        /// Reads the current state root from metadata.
-        fn state_root(scheduler: &Scheduler<RocksDbStore, Processor>) -> [u8; 32] {
-            StateMetadata::state_root(&**scheduler.state().storage().store())
-        }
-
         // Before any batches, state root should be empty.
         assert_eq!(state_root(&scheduler), EMPTY_HASH);
 
@@ -1622,10 +1623,6 @@ pub fn test_smt_state_root_after_rollback() {
             ExecutionConfig::default().with_processor(Processor),
             StorageConfig::default().with_store(storage),
         );
-
-        fn state_root(scheduler: &Scheduler<RocksDbStore, Processor>) -> [u8; 32] {
-            StateMetadata::state_root(&**scheduler.state().storage().store())
-        }
 
         // Commit 3 batches, each touching a distinct resource.
         let batch1 = scheduler.schedule(
@@ -1702,10 +1699,6 @@ pub fn test_smt_state_root_rollback_to_zero() {
             StorageConfig::default().with_store(storage),
         );
 
-        fn state_root(scheduler: &Scheduler<RocksDbStore, Processor>) -> [u8; 32] {
-            StateMetadata::state_root(&**scheduler.state().storage().store())
-        }
-
         // Commit a batch so the root is non-empty.
         let batch1 = scheduler.schedule(
             1,
@@ -1780,12 +1773,8 @@ pub fn test_smt_multi_resource_single_batch() {
         );
         batch.wait_committed_blocking();
 
-        let store = scheduler.state().storage().store();
-        let root = StateMetadata::state_root(&**store);
+        let root = state_root(&scheduler);
         assert_ne!(root, EMPTY_HASH, "multi-resource batch should produce non-empty root");
-
-        // Tree version root should agree with metadata.
-        assert_eq!(store.root(1), root);
 
         scheduler.shutdown();
     }
@@ -1949,10 +1938,6 @@ pub fn test_smt_deterministic_roots() {
             ExecutionConfig::default().with_processor(Processor),
             StorageConfig::default().with_store(storage),
         );
-
-        fn state_root(scheduler: &Scheduler<RocksDbStore, Processor>) -> [u8; 32] {
-            StateMetadata::state_root(&**scheduler.state().storage().store())
-        }
 
         // Commit batch 1, record root.
         let batch1 = scheduler.schedule(
@@ -2428,7 +2413,7 @@ pub fn test_restore_smt_root_is_idempotent() {
             )],
         );
         batch1.wait_committed_blocking();
-        let root_before = StateMetadata::state_root(&**scheduler.state().storage().store());
+        let root_before = scheduler.state().storage().store().root(1);
 
         // Reorg away, then restore the same block.
         scheduler.rollback_to(0).expect("rollback should succeed");
@@ -2444,12 +2429,7 @@ pub fn test_restore_smt_root_is_idempotent() {
 
         // The re-run store.update reproduces the same tree: same state root, same per-version root.
         let store = scheduler.state().storage().store();
-        assert_eq!(
-            StateMetadata::state_root(&**store),
-            root_before,
-            "restored state root must match the original"
-        );
-        assert_eq!(store.root(1), root_before, "restored per-version root must match the original");
+        assert_eq!(store.root(1), root_before, "restored SMT root must match the original");
 
         scheduler.shutdown();
     }

--- a/scheduling/test-utils/src/processor.rs
+++ b/scheduling/test-utils/src/processor.rs
@@ -46,6 +46,10 @@ impl<S: Store> vprogs_scheduling_scheduler::Processor<S> for Processor {
         [2u8; 32]
     }
 
+    fn supports_restore(&self) -> bool {
+        true
+    }
+
     type Transaction = usize;
     type TransactionArtifact = Vec<u8>;
     type BatchArtifact = Vec<u8>;

--- a/state/batch-metadata/src/lib.rs
+++ b/state/batch-metadata/src/lib.rs
@@ -8,21 +8,20 @@ pub struct BatchMetadata;
 
 impl BatchMetadata {
     /// Returns the deserialized metadata for a batch, or `M::default()` if not found.
-    pub fn get<M: BatchMetadataTrait, S>(store: &S, batch_index: u64) -> M
-    where
-        S: Store,
-    {
+    pub fn get<M: BatchMetadataTrait, S: Store>(store: &S, batch_index: u64) -> M {
         store
             .get(StateSpace::BatchMetadata, &batch_index.to_be_bytes())
             .map(|bytes| borsh::from_slice(&bytes).expect("corrupted store: unrecoverable"))
             .unwrap_or_default()
     }
 
+    /// Returns whether a batch has a metadata entry (committed and not yet pruned).
+    pub fn exists<S: Store>(store: &S, batch_index: u64) -> bool {
+        store.get(StateSpace::BatchMetadata, &batch_index.to_be_bytes()).is_some()
+    }
+
     /// Stores serialized metadata for a batch.
-    pub fn set<M: BatchMetadataTrait, W>(wb: &mut W, batch_index: u64, metadata: &M)
-    where
-        W: WriteBatch,
-    {
+    pub fn set<M: BatchMetadataTrait, W: WriteBatch>(wb: &mut W, batch_index: u64, metadata: &M) {
         wb.put(
             StateSpace::BatchMetadata,
             &batch_index.to_be_bytes(),
@@ -31,10 +30,7 @@ impl BatchMetadata {
     }
 
     /// Deletes the metadata entry for a single batch index.
-    pub fn delete<W>(wb: &mut W, batch_index: u64)
-    where
-        W: WriteBatch,
-    {
+    pub fn delete<W: WriteBatch>(wb: &mut W, batch_index: u64) {
         wb.delete(StateSpace::BatchMetadata, &batch_index.to_be_bytes());
     }
 }

--- a/state/metadata/src/lib.rs
+++ b/state/metadata/src/lib.rs
@@ -1,4 +1,3 @@
-use vprogs_core_smt::EMPTY_HASH;
 use vprogs_core_types::{BatchMetadata, Checkpoint};
 use vprogs_storage_types::{ReadStore, StateSpace, WriteBatch};
 
@@ -8,8 +7,6 @@ mod keys {
     pub const ROOT: &[u8] = b"root";
     /// Key for the last committed batch (index + metadata stored together).
     pub const LAST_COMMITTED: &[u8] = b"last_committed";
-    /// Key for the 32-byte global state root hash.
-    pub const STATE_ROOT: &[u8] = b"smt_root";
 }
 
 /// Provides type-safe operations for the Metadata column family.
@@ -67,18 +64,5 @@ impl StateMetadata {
             keys::LAST_COMMITTED,
             &borsh::to_vec(checkpoint).expect("failed to serialize Checkpoint"),
         );
-    }
-
-    /// Returns the current global state root hash, or `EMPTY_HASH` if none has been set.
-    pub fn state_root<S: ReadStore>(store: &S) -> [u8; 32] {
-        store
-            .get(StateSpace::Metadata, keys::STATE_ROOT)
-            .map(|bytes| bytes.try_into().expect("corrupted state_root: unrecoverable"))
-            .unwrap_or(EMPTY_HASH)
-    }
-
-    /// Sets the global state root hash.
-    pub fn set_state_root<W: WriteBatch>(wb: &mut W, root: &[u8; 32]) {
-        wb.put(StateSpace::Metadata, keys::STATE_ROOT, root);
     }
 }

--- a/state/ptr-rollback/src/lib.rs
+++ b/state/ptr-rollback/src/lib.rs
@@ -1,6 +1,6 @@
 use vprogs_core_types::ResourceId;
 use vprogs_storage_manager::concat_bytes;
-use vprogs_storage_types::{StateSpace, Store, WriteBatch};
+use vprogs_storage_types::{ReadStore, StateSpace, Store, WriteBatch};
 
 /// Provides type-safe operations for the RollbackPtr column family.
 ///
@@ -20,6 +20,15 @@ impl StatePtrRollback {
         let rid = borsh::to_vec(resource_id).expect("failed to serialize ResourceId");
         let key = concat_bytes!(&batch_index.to_be_bytes(), &rid);
         wb.put(StateSpace::StatePtrRollback, &key, &old_version.to_be_bytes());
+    }
+
+    /// Returns the version `resource_id` had before `batch_index`, or `None` if it wasn't written.
+    pub fn get<S: ReadStore>(store: &S, batch_index: u64, resource_id: &ResourceId) -> Option<u64> {
+        let rid = borsh::to_vec(resource_id).expect("failed to serialize ResourceId");
+        let key = concat_bytes!(&batch_index.to_be_bytes(), &rid);
+        store
+            .get(StateSpace::StatePtrRollback, &key)
+            .map(|bytes| u64::from_be_bytes(bytes[..8].try_into().unwrap()))
     }
 
     /// Deletes a rollback pointer entry.

--- a/state/version/src/lib.rs
+++ b/state/version/src/lib.rs
@@ -30,6 +30,11 @@ impl StateVersion {
         }
     }
 
+    /// Loads the resource's data at a specific version, or empty data if absent.
+    pub fn at_version<S: ReadStore>(store: &S, version: u64, id: ResourceId) -> Self {
+        Self { resource_id: id, version, data: Self::get(store, version, &id).unwrap_or_default() }
+    }
+
     pub fn version(&self) -> u64 {
         self.version
     }

--- a/zk/vm/src/vm.rs
+++ b/zk/vm/src/vm.rs
@@ -77,6 +77,11 @@ impl<B: Backend, S: Store> Processor<S> for Vm<B, S> {
         *self.backend.aggregator_image_id()
     }
 
+    /// Restore is safe only without proving; any proving mode needs per-tx pre-images.
+    fn supports_restore(&self) -> bool {
+        matches!(*self.proving_pipeline, ProvingPipeline::None)
+    }
+
     type Transaction = L1Transaction;
     type TransactionArtifact = B::Receipt;
     type BatchArtifact = B::Receipt;


### PR DESCRIPTION
Builds on `feat/canonical-chain`. When a previously committed block returns after a reorg (a "reorg-back"), the scheduler now restores that batch's state from disk instead of re-executing its transactions.

## Motivation

The canonical-chain machinery assigns never-reused ids and keeps an orphaned batch's committed state on disk until finalization. Today, when such a block returns, we re-execute it from scratch even though its result is already persisted. This change lets the scheduler fast-forward to the already-committed state, skipping re-execution for the common reorg-back case.

## How it works

Restore is a disk read that replaces execution; the unchanged commit path then runs.

- **Detection** (`Scheduler::next_checkpoint`): a returning id is restorable when the canonical chain reports it is not new (`AppendOutcome.is_new == false`) and its committed metadata is still on disk (`BatchMetadata::exists`). New ids never touch disk (the check short-circuits).
- **Read** (`Read::CommittedBatch` then `ScheduledBatch::restore_committed`): for each resource the batch touched, `ResourceAccess::restore_committed_data` reads the pre- and post-batch versions from disk (`StatePtrRollback::get` + `StateVersion::at_version`) and applies them to the in-memory chain exactly as execution would. The read state goes on the diff; the written state goes on the tail access, which persists the diff once and forwards the value to a following batch in memory. It is the sibling of the existing `read_latest_data`.
- **Commit reuse**: a restored batch goes through the normal commit path unchanged. `store.update` re-runs and reproduces the same SMT (idempotent against the retained nodes), so there is no parallel commit logic.
- **Lifecycle**: `restore_committed` opens only the processing latch (`processed`); the proving latches are left to the prover.

## Gating and safety

Restore skips execution, so it is only safe for processors that need nothing from execution beyond the committed aggregate state. It is opt-in:

- `Processor::supports_restore() -> bool` defaults to `false` (always re-execute).
- The test processor and the exec-only `Vm` (`ProvingPipeline::None`) opt in.
- Any proving mode keeps re-executing, because proving needs per-transaction pre-images that restore does not reconstruct.
- `ScheduledBatch::restored()` marks a restored batch: the seam the proving side will build on.

Exec-only deployments get the optimization now, proving deployments stay correct by re-executing, and unaware or future processors are safe by default.

## Out of scope

Proving deployments do not yet benefit; they re-execute. Wiring restore through the proving pipeline (reload persisted proofs, or source per-transaction pre-images for unproven batches) is tracked as a follow-up issue.

## Tests

Three end-to-end tests (`scheduling/scheduler/tests/e2e.rs`):

- restore reuses the committed state and does not re-execute (a returning block carrying a different tx payload is ignored),
- a restored batch feeds its state into a following batch through the in-memory chain,
- committing a restored batch reproduces the original SMT root (idempotent `store.update`).

## Changed files (vs `feat/canonical-chain`)

- `scheduling/scheduler`: `Read::CommittedBatch`, `restore_committed`, `restore_committed_data`, the `restored` flag, the `schedule` restore branch, the `next_checkpoint` gate, `Processor::supports_restore`.
- `state`: `BatchMetadata::exists`, `StatePtrRollback::get`, `StateVersion::at_version`.
- `scheduling/test-utils`, `zk/vm`: `supports_restore` overrides.
