### PR TITLE
Bridge worker: surface malformed RPC responses as Fatal instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8640,6 +8640,7 @@ name = "vprogs-l1-bridge"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "borsh",
  "crossbeam-queue",
  "futures",
  "kaspa-consensus-core",
@@ -8651,6 +8652,7 @@ dependencies = [
  "tap",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "vprogs-core-atomics",
  "vprogs-core-macros",
  "vprogs-core-types",
@@ -8658,6 +8660,8 @@ dependencies = [
  "vprogs-node-test-utils",
  "vprogs-storage-canonical-chain",
  "workflow-core",
+ "workflow-rpc",
+ "workflow-serializer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,42 +54,44 @@ resolver = "3"
 
   [workspace.dependencies]
   # External dependencies
-  arc-swap              = "1.7"
-  borsh                 = { version = "1.6.0", default-features = false, features = ["derive"] }
-  clap                  = { version = "4", features = ["derive"] }
-  crossbeam-deque       = "0.8.6"
-  crossbeam-queue       = "0.3.12"
-  crossbeam-utils       = "0.8.21"
-  ctrlc                 = { version = "3", features = ["termination"] }
-  env_logger            = "0.11"
-  faster-hex            = "0.9"
-  fastrand              = "2.3.0"
-  figment               = { version = "0.10", features = ["toml", "env"] }
-  futures               = "0.3.31"
-  indexmap              = "2"
+  arc-swap = "1.7"
+  borsh = { version = "1.6.0", default-features = false, features = ["derive"] }
+  clap = { version = "4", features = ["derive"] }
+  crossbeam-deque = "0.8.6"
+  crossbeam-queue = "0.3.12"
+  crossbeam-utils = "0.8.21"
+  ctrlc = { version = "3", features = ["termination"] }
+  env_logger = "0.11"
+  faster-hex = "0.9"
+  fastrand = "2.3.0"
+  figment = { version = "0.10", features = ["toml", "env"] }
+  futures = "0.3.31"
+  indexmap = "2"
   intrusive-collections = "0.9.7"
-  log                   = "0.4"
-  num_cpus              = "1.17.0"
-  pin-project-lite      = "0.2"
-  proc-macro2           = "1.0.103"
-  quote                 = "1.0.42"
-  rand                  = "0.8"
-  rand_distr            = "0.4"
-  secp256k1             = { version = "0.29.1", features = ["rand-std"] }
-  serde                 = { version = "1", features = ["derive"] }
-  serde_json            = "1"
-  syn                   = { version = "2.0.111", features = ["full"] }
-  tap                   = "1.0.1"
-  tempfile              = "3.23.0"
-  thiserror             = { version = "2", default-features = false }
-  tokio                 = { version = "1", features = ["rt", "sync"] }
-  tokio-tungstenite     = "0.23"
-  tokio-util            = "0.7.17"
-  toml                  = "0.8"
-  workflow-core         = "0.18.0"
-  workflow-rpc          = { version = "0.18.0", default-features = false, features = ["rustls-tls-webpki-roots"] }
-  workflow-serializer   = "0.18.0"
-  zerocopy              = { version = "0.8", default-features = false }
+  log = "0.4"
+  num_cpus = "1.17.0"
+  pin-project-lite = "0.2"
+  proc-macro2 = "1.0.103"
+  quote = "1.0.42"
+  rand = "0.8"
+  rand_distr = "0.4"
+  secp256k1 = { version = "0.29.1", features = ["rand-std"] }
+  serde = { version = "1", features = ["derive"] }
+  serde_json = "1"
+  syn = { version = "2.0.111", features = ["full"] }
+  tap = "1.0.1"
+  tempfile = "3.23.0"
+  thiserror = { version = "2", default-features = false }
+  tokio = { version = "1", features = ["rt", "sync"] }
+  tokio-tungstenite = "0.23"
+  tokio-util = "0.7.17"
+  toml = "0.8"
+  workflow-core = "0.18.0"
+  workflow-rpc = { version = "0.18.0", default-features = false, features = [
+    "rustls-tls-webpki-roots",
+  ] }
+  workflow-serializer = "0.18.0"
+  zerocopy = { version = "0.8", default-features = false }
   # jemalloc is intentionally omitted here: it does not build on Windows, so it is enabled
   # per-target in storage/rocksdb-store and propagated to the build via Cargo feature unification.
   rocksdb = { version = "0.24.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,12 @@ resolver = "3"
   tempfile              = "3.23.0"
   thiserror             = { version = "2", default-features = false }
   tokio                 = { version = "1", features = ["rt", "sync"] }
+  tokio-tungstenite     = "0.23"
   tokio-util            = "0.7.17"
   toml                  = "0.8"
   workflow-core         = "0.18.0"
+  workflow-rpc          = { version = "0.18.0", default-features = false, features = ["rustls-tls-webpki-roots"] }
+  workflow-serializer   = "0.18.0"
   zerocopy              = { version = "0.8", default-features = false }
   # jemalloc is intentionally omitted here: it does not build on Windows, so it is enabled
   # per-target in storage/rocksdb-store and propagated to the build via Cargo feature unification.

--- a/l1/bridge/Cargo.toml
+++ b/l1/bridge/Cargo.toml
@@ -23,10 +23,15 @@ vprogs-l1-types.workspace      = true
 workflow-core.workspace        = true
 
 [dev-dependencies]
-borsh.workspace                          = true
-tokio                                    = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }
-tokio-tungstenite.workspace              = true
-vprogs-node-test-utils.workspace         = true
+borsh.workspace = true
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "time",
+  "net",
+] }
+tokio-tungstenite.workspace = true
+vprogs-node-test-utils.workspace = true
 vprogs-storage-canonical-chain.workspace = true
-workflow-rpc.workspace                   = true
-workflow-serializer.workspace            = true
+workflow-rpc.workspace = true
+workflow-serializer.workspace = true

--- a/l1/bridge/Cargo.toml
+++ b/l1/bridge/Cargo.toml
@@ -23,6 +23,10 @@ vprogs-l1-types.workspace      = true
 workflow-core.workspace        = true
 
 [dev-dependencies]
-tokio                                    = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+borsh.workspace                          = true
+tokio                                    = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }
+tokio-tungstenite.workspace              = true
 vprogs-node-test-utils.workspace         = true
 vprogs-storage-canonical-chain.workspace = true
+workflow-rpc.workspace                   = true
+workflow-serializer.workspace            = true

--- a/l1/bridge/src/error.rs
+++ b/l1/bridge/src/error.rs
@@ -16,6 +16,10 @@ pub(crate) enum Error {
     #[error("reorg below finalization boundary: fork block {0} is finalized")]
     ReorgBelowFinality(Hash),
 
+    /// The peer elided a response field required at `Full` verbosity - retrying cannot help.
+    #[error("malformed RPC response: {0}")]
+    MalformedResponse(String),
+
     /// An internal channel closed unexpectedly.
     #[error("notification channel closed: {0}")]
     ChannelClosed(String),

--- a/l1/bridge/src/worker.rs
+++ b/l1/bridge/src/worker.rs
@@ -13,7 +13,6 @@ use kaspa_notify::scope::{PruningPointUtxoSetOverrideScope, Scope, VirtualChainC
 use kaspa_rpc_core::{
     GetVirtualChainFromBlockV2Response, Notification,
     RpcDataVerbosityLevel::Full,
-    RpcOptionalHeader,
     api::{ctl::RpcState, rpc::RpcApi},
 };
 use kaspa_seq_commit::{
@@ -453,41 +452,42 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
 
         // Schedule each new block, threading its parent from the current tip.
         for chain_block in response.chain_block_accepted_transactions.iter() {
+            // Validate the peer-controlled header up front; an elided field fails the sync and
+            // downstream code sees only the validated metadata.
+            let block = ChainBlockMetadata::try_from(&chain_block.chain_block_header)
+                .map_err(|field| Error::MalformedResponse(field.into()))?;
+
             // The block's parent; its `last_settlement` carries forward, updated per tx below.
-            let header = &chain_block.chain_block_header;
             let parent = self.tip_metadata();
-            let block_hash = header.hash.expect("missing hash");
-            let block_daa = header.daa_score.expect("missing daa_score");
             let mut last_settlement = parent.last_settlement;
 
             // Enumerate before filtering so kept txs keep their block-wide positions.
-            let txs: Vec<SchedulerTransaction<L1Transaction>> = chain_block
-                .accepted_transactions
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, tx)| {
-                    // Carry forward the last settlement.
-                    let tx = L1Transaction::try_from(tx.clone()).expect("missing tx fields");
-                    if let Some(id) = self.covenant_id {
-                        last_settlement =
-                            tx.settlement_info(id, block_hash, block_daa).or(last_settlement);
-                    }
+            let mut txs: Vec<SchedulerTransaction<L1Transaction>> =
+                Vec::with_capacity(chain_block.accepted_transactions.len());
+            for (idx, tx) in chain_block.accepted_transactions.iter().enumerate() {
+                // Same trust boundary as the header: elided tx fields fail the sync.
+                let tx = L1Transaction::try_from(tx.clone())
+                    .map_err(|e| Error::MalformedResponse(e.to_string()))?;
 
-                    // Parse access metadata; marlformed = no dependencies and prover attests.
-                    match self.subnetwork_filter.as_ref() {
-                        Some(want) if tx.subnetwork_id != *want => None,
-                        _ => Some(SchedulerTransaction::new(
-                            idx as u32,
-                            AccessMetadata::decode_vec(&mut tx.payload.as_slice())
-                                .unwrap_or_default(),
-                            tx,
-                        )),
-                    }
-                })
-                .collect();
+                // Carry forward the last settlement.
+                if let Some(id) = self.covenant_id {
+                    last_settlement =
+                        tx.settlement_info(id, block.hash, block.daa_score).or(last_settlement);
+                }
+
+                // Parse access metadata; malformed = no dependencies and prover attests.
+                match self.subnetwork_filter.as_ref() {
+                    Some(want) if tx.subnetwork_id != *want => {}
+                    _ => txs.push(SchedulerTransaction::new(
+                        idx as u32,
+                        AccessMetadata::decode_vec(&mut tx.payload.as_slice()).unwrap_or_default(),
+                        tx,
+                    )),
+                }
+            }
 
             // Determine the lane tip over the block's accepted txs.
-            let (lane_tip, lane_blue_score, lane_expired) = self.lane_state(&parent, &txs, header);
+            let (lane_tip, lane_blue_score, lane_expired) = self.lane_state(&parent, &txs, &block);
 
             // Append the block's parent-threaded metadata and its txs to the sink.
             self.sink.append(
@@ -502,7 +502,7 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
                     lane_tip,
                     lane_expired,
                     last_settlement,
-                    ..ChainBlockMetadata::try_from(header).unwrap()
+                    ..block
                 },
                 txs,
             );
@@ -520,10 +520,10 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
         &self,
         parent: &ChainBlockMetadata,
         txs: &[SchedulerTransaction<L1Transaction>],
-        header: &RpcOptionalHeader,
+        block: &ChainBlockMetadata,
     ) -> (Hash, u64, bool) {
         // Check whether the lane has gone silent past the finality window and needs to reset.
-        let blue_score = header.blue_score.expect("missing blue_score");
+        let blue_score = block.blue_score;
         let lane_expired = blue_score.saturating_sub(parent.lane_blue_score) > self.finality_depth;
 
         // No lane configured or no activity this block -> carry parent state forward unchanged.
@@ -540,7 +540,7 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
         // Context hash of the current chain block.
         let context_hash = mergeset_context_hash(&MergesetContext {
             timestamp: parent.timestamp,
-            daa_score: header.daa_score.expect("missing daa_score"),
+            daa_score: block.daa_score,
             blue_score,
         });
 

--- a/l1/bridge/src/worker.rs
+++ b/l1/bridge/src/worker.rs
@@ -325,12 +325,14 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
         // Lowest verbosity (no txs): we need each block's selected parent, then the landing header.
         let mut hash = sink;
         for _ in 0..depth {
+            // Same trust boundary as the sync path: the peer carries verbose data as an `Option`,
+            // and without it there is no parent to walk to.
             let parent = self
                 .client
                 .get_block(hash, false)
                 .await?
                 .verbose_data
-                .expect("get_block returns verbose data")
+                .ok_or(Error::MalformedResponse("missing block verbose_data".into()))?
                 .selected_parent_hash;
             if parent == hash {
                 break;

--- a/l1/bridge/tests/malformed_response.rs
+++ b/l1/bridge/tests/malformed_response.rs
@@ -1,13 +1,11 @@
-//! Reproduction: the bridge worker `expect`/`unwrap`s fields the RPC peer carries as `Option`, so a
-//! peer that elides one panics the worker thread. The worker runs on a bare `thread::spawn` with no
-//! `catch_unwind`, so the panic never becomes an [`L1Event::Fatal`]: the thread dies, the sink stops
-//! advancing, and consumers parked in `wait_and_pop` block forever with no indication.
+//! Malformed-response handling: the RPC peer carries header and transaction fields as `Option`,
+//! and `L1BridgeConfig::default()` reaches the public community resolver, so the peer serving them
+//! is untrusted. A peer that elides a required field can never yield progress, so the bridge owes
+//! its consumers a terminal [`L1Event::Fatal`]. A worker panic instead would kill the worker
+//! thread silently, stop the sink, and park `wait_and_pop` consumers forever with no indication.
 //!
 //! Each test drives a real L1 node through a proxy that elides exactly one field from every
 //! `GetVirtualChainFromBlockV2` response, then asserts the bridge reports the malformed response.
-//!
-//! `L1BridgeConfig::default()` reaches the public community resolver, so the peer serving these
-//! responses is untrusted and this is a remote liveness kill.
 
 use std::{
     panic,
@@ -43,15 +41,17 @@ use workflow_serializer::prelude::Serializable;
 const TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Time a consumer waits for the event the worker owes it after the tampered response. The worker
-/// reaches the site within milliseconds of the response, so exceeding this means none is coming.
+/// reaches the elided field within milliseconds of the response, so exceeding this means none is
+/// coming.
 const FATAL_TIMEOUT: Duration = Duration::from_secs(15);
 
 // ============================================================================
 // Panic recording
 // ============================================================================
 
-/// Panic reports from every thread in this binary, including the bridge worker's. Each entry
-/// carries the panicking source location, which names the site that consumed the elided field.
+/// Panic reports from every thread in this binary, including the bridge worker's. A recorded
+/// worker panic is the diagnostic when an assert below fails: its source location names the code
+/// that consumed the elided field instead of surfacing an error.
 static PANICS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 /// Installs a hook recording every panic report while keeping the default one. Idempotent.
@@ -66,17 +66,16 @@ fn record_panics() {
     });
 }
 
-/// The recorded panic reports raised at `site`, a `file.rs:line` location under `l1/bridge/src`.
+/// The recorded panic reports raised under `l1/bridge/src`, where the worker consumes wire fields.
 ///
-/// Matching the location rather than the whole report keeps a sibling test's assert text, which
-/// quotes these same sites, out of the result.
-fn panics_at(site: &str) -> Vec<String> {
-    let location = format!("panicked at l1/bridge/src/{site}:");
+/// Matching the location keeps this binary's own panics, such as a sibling test's assert, out of
+/// the result.
+fn bridge_panics() -> Vec<String> {
     PANICS
         .lock()
         .expect("panic log poisoned")
         .iter()
-        .filter(|p| p.starts_with(&location))
+        .filter(|p| p.starts_with("panicked at l1/bridge/src/"))
         .cloned()
         .collect()
 }
@@ -85,21 +84,19 @@ fn panics_at(site: &str) -> Vec<String> {
 // The tampered field, one per panic site
 // ============================================================================
 
-/// A single field elided from every `GetVirtualChainFromBlockV2` response, named for the worker
-/// site that consumes it without checking. An honest node at `Full` verbosity always populates
-/// these; a malicious one is free not to.
+/// A single field elided from every `GetVirtualChainFromBlockV2` response. An honest node at
+/// `Full` verbosity always populates these; a malicious one is free not to.
 #[derive(Clone, Copy, Debug)]
 enum Elide {
-    /// `worker.rs:459` - `header.hash.expect("missing hash")`.
+    /// The chain-block header's `hash`.
     HeaderHash,
-    /// `worker.rs:460` - `header.daa_score.expect("missing daa_score")`.
+    /// The chain-block header's `daa_score`.
     HeaderDaaScore,
-    /// `worker.rs:470` - `L1Transaction::try_from(tx.clone()).expect("missing tx fields")`.
+    /// An accepted transaction's `storage_mass`, required by the L1 transaction conversion.
     TxStorageMass,
-    /// `worker.rs:505` - `ChainBlockMetadata::try_from(header).unwrap()`, which also requires
-    /// `timestamp`. Reached only once the fields checked earlier in the loop are present.
+    /// The chain-block header's `timestamp`.
     HeaderTimestamp,
-    /// `worker.rs:526` - `header.blue_score.expect("missing blue_score")` in `lane_state`.
+    /// The chain-block header's `blue_score`.
     HeaderBlueScore,
 }
 
@@ -242,8 +239,8 @@ fn tamper(bytes: &[u8], elide: Elide, elided: &AtomicUsize) -> Option<Message> {
     let mut response = VccReply::deserialize(&mut &message.payload[..]).ok()?.ok()?.into_inner();
     elided.fetch_add(elide.apply(&mut response), Ordering::Relaxed);
 
-    let payload = borsh::to_vec::<VccReply>(&Ok(Serializable(response)))
-        .expect("response must reserialize");
+    let payload =
+        borsh::to_vec::<VccReply>(&Ok(Serializable(response))).expect("response must reserialize");
     let header =
         BorshServerMessageHeader::new(message.header.id, message.header.kind, message.header.op);
     let rewritten =
@@ -360,7 +357,7 @@ async fn setup(elide: Elide) -> Harness {
 /// The bridge owes every consumer either progress or a terminal event. A peer that elides a
 /// required field can never yield progress, so `Fatal` is the only outcome left. Panicking on the
 /// worker thread delivers neither.
-async fn assert_fatal_on_elided_field(elide: Elide, site: &str) {
+async fn assert_fatal_on_elided_field(elide: Elide) {
     let h = setup(elide).await;
 
     // Kaspa accepts a block's transactions on the next chain block, so the second block puts the
@@ -371,61 +368,54 @@ async fn assert_fatal_on_elided_field(elide: Elide, site: &str) {
     let event = tokio::time::timeout(FATAL_TIMEOUT, h.bridge.wait_and_pop()).await;
     assert!(
         matches!(event, Ok(L1Event::Fatal { .. })),
-        "{site}: expected Fatal on the elided field, got {event:?}. The worker scheduled {} \
+        "{elide:?}: expected Fatal on the elided field, got {event:?}. The worker scheduled {} \
          blocks, and panicked at: {:?}",
         h.sink.scheduled(),
-        panics_at(site),
+        bridge_panics(),
     );
 
     h.node.shutdown().await;
 }
 
 // ============================================================================
-// One case per panic site
+// One case per elidable field
 // ============================================================================
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_hash_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderHash, "worker.rs:459").await;
+    assert_fatal_on_elided_field(Elide::HeaderHash).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_daa_score_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderDaaScore, "worker.rs:460").await;
+    assert_fatal_on_elided_field(Elide::HeaderDaaScore).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_transaction_storage_mass_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::TxStorageMass, "worker.rs:470").await;
+    assert_fatal_on_elided_field(Elide::TxStorageMass).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_timestamp_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderTimestamp, "worker.rs:505").await;
+    assert_fatal_on_elided_field(Elide::HeaderTimestamp).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_blue_score_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderBlueScore, "worker.rs:526").await;
+    assert_fatal_on_elided_field(Elide::HeaderBlueScore).await;
 }
 
-// `worker.rs:543` (`header.daa_score.expect("missing daa_score")` in `lane_state`) has no case of
-// its own, and no response can give it one. It reads the same `Option` on the same header that
-// `worker.rs:460` unwraps earlier in the same loop iteration, so every response that would trip it
-// trips `:460` first. `elided_header_daa_score_reports_fatal` covers the field; a fix to `:543`
-// alone is unobservable, and a fix to `:460` alone leaves `:543` reachable and must be checked by
-// review rather than by this test.
-
 // ============================================================================
-// The consequence: a dead worker and a parked consumer
+// Observability: progress or a terminal event, never silence
 // ============================================================================
 
 /// Verifies the bridge stays observable after a malformed response: it either keeps scheduling or
 /// says why it stopped.
 ///
-/// After the panic the worker thread is gone, so no further block is scheduled and no event is ever
-/// queued. Nothing observable distinguishes that from a quiet chain, and a consumer in
-/// `wait_and_pop` parks forever.
+/// A worker that panicked instead would be gone: no further block scheduled, no event ever queued,
+/// nothing observable to distinguish it from a quiet chain, and a consumer in `wait_and_pop`
+/// parked forever.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn malformed_response_leaves_the_bridge_observable() {
     let h = setup(Elide::HeaderDaaScore).await;
@@ -447,7 +437,7 @@ async fn malformed_response_leaves_the_bridge_observable() {
         progressed || !events.is_empty(),
         "after the malformed response the bridge neither scheduled a block (stuck at \
          {scheduled_before}) nor queued an event to say why; its worker panicked at: {:?}",
-        panics_at("worker.rs:460"),
+        bridge_panics(),
     );
 
     h.node.shutdown().await;

--- a/l1/bridge/tests/malformed_response.rs
+++ b/l1/bridge/tests/malformed_response.rs
@@ -4,8 +4,8 @@
 //! its consumers a terminal [`L1Event::Fatal`]. A worker panic instead would kill the worker
 //! thread silently, stop the sink, and park `wait_and_pop` consumers forever with no indication.
 //!
-//! Each test drives a real L1 node through a proxy that elides exactly one field from every
-//! `GetVirtualChainFromBlockV2` response, then asserts the bridge reports the malformed response.
+//! Each test drives a real L1 node through a proxy that elides exactly one field from every reply
+//! carrying it, then asserts the bridge reports the malformed response.
 
 use std::{
     panic,
@@ -19,7 +19,7 @@ use std::{
 use borsh::BorshDeserialize;
 use futures::{SinkExt, StreamExt};
 use kaspa_consensus_core::network::NetworkId;
-use kaspa_rpc_core::{GetVirtualChainFromBlockV2Response, api::ops::RpcApiOps};
+use kaspa_rpc_core::{GetBlockResponse, GetVirtualChainFromBlockV2Response, api::ops::RpcApiOps};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::mpsc,
@@ -84,10 +84,19 @@ fn bridge_panics() -> Vec<String> {
 // The tampered field, one per panic site
 // ============================================================================
 
-/// A single field elided from every `GetVirtualChainFromBlockV2` response. An honest node at
-/// `Full` verbosity always populates these; a malicious one is free not to.
+/// A single field elided from every reply carrying it. An honest node at `Full` verbosity always
+/// populates these; a malicious one is free not to.
 #[derive(Clone, Copy, Debug)]
 enum Elide {
+    /// A field of the virtual-chain reply, read while syncing.
+    Chain(ChainField),
+    /// A block's `verbose_data`, read while seeding the genesis anchor below the sink.
+    BlockVerboseData,
+}
+
+/// A field of a `GetVirtualChainFromBlockV2` response the worker reads.
+#[derive(Clone, Copy, Debug)]
+enum ChainField {
     /// The chain-block header's `hash`.
     HeaderHash,
     /// The chain-block header's `daa_score`.
@@ -101,17 +110,50 @@ enum Elide {
 }
 
 impl Elide {
-    /// Removes this variant's field throughout `response`, returning how many were removed.
+    /// The reply this field is elided from.
+    fn op(self) -> RpcApiOps {
+        match self {
+            Elide::Chain(_) => RpcApiOps::GetVirtualChainFromBlockV2,
+            Elide::BlockVerboseData => RpcApiOps::GetBlock,
+        }
+    }
+
+    /// Rewrites `payload` without this field, returning the rewritten payload and how many fields
+    /// it removed, or `None` if the payload is not the reply's success arm.
+    fn apply(self, payload: &[u8]) -> Option<(Vec<u8>, usize)> {
+        match self {
+            Elide::Chain(field) => {
+                let mut response =
+                    VccReply::deserialize(&mut &payload[..]).ok()?.ok()?.into_inner();
+                let elided = field.apply(&mut response);
+                let payload = borsh::to_vec::<VccReply>(&Ok(Serializable(response)))
+                    .expect("response must reserialize");
+                Some((payload, elided))
+            }
+            Elide::BlockVerboseData => {
+                let mut response =
+                    BlockReply::deserialize(&mut &payload[..]).ok()?.ok()?.into_inner();
+                let elided = response.block.verbose_data.take().is_some() as usize;
+                let payload = borsh::to_vec::<BlockReply>(&Ok(Serializable(response)))
+                    .expect("response must reserialize");
+                Some((payload, elided))
+            }
+        }
+    }
+}
+
+impl ChainField {
+    /// Removes this field throughout `response`, returning how many were removed.
     fn apply(self, response: &mut GetVirtualChainFromBlockV2Response) -> usize {
         let mut elided = 0;
         for block in Arc::make_mut(&mut response.chain_block_accepted_transactions) {
             let header = &mut block.chain_block_header;
             elided += match self {
-                Elide::HeaderHash => header.hash.take().is_some() as usize,
-                Elide::HeaderDaaScore => header.daa_score.take().is_some() as usize,
-                Elide::HeaderTimestamp => header.timestamp.take().is_some() as usize,
-                Elide::HeaderBlueScore => header.blue_score.take().is_some() as usize,
-                Elide::TxStorageMass => block
+                ChainField::HeaderHash => header.hash.take().is_some() as usize,
+                ChainField::HeaderDaaScore => header.daa_score.take().is_some() as usize,
+                ChainField::HeaderTimestamp => header.timestamp.take().is_some() as usize,
+                ChainField::HeaderBlueScore => header.blue_score.take().is_some() as usize,
+                ChainField::TxStorageMass => block
                     .accepted_transactions
                     .iter_mut()
                     .map(|tx| tx.storage_mass.take().is_some() as usize)
@@ -128,9 +170,9 @@ impl Elide {
 
 /// A wRPC proxy between the bridge and a real L1 node.
 ///
-/// It forwards every frame verbatim except successful replies to `GetVirtualChainFromBlockV2`, from
-/// which it elides one field, and counts what it removed so a test can establish that the worker
-/// was actually served a malformed response.
+/// It forwards every frame verbatim except the successful replies carrying the tampered field, from
+/// which it elides that one field, and counts what it removed so a test can establish that the
+/// worker was actually served a malformed response.
 struct TamperProxy {
     /// URL the bridge connects to, standing in for the node's own wRPC URL.
     url: String,
@@ -187,7 +229,7 @@ impl TamperProxy {
     }
 }
 
-/// Relays frames both ways, eliding a field from every virtual-chain response.
+/// Relays frames both ways, eliding a field from every response carrying it.
 async fn pump(
     downstream: WebSocketStream<TcpStream>,
     upstream: WebSocketStream<MaybeTlsStream<TcpStream>>,
@@ -225,22 +267,23 @@ async fn pump(
 /// A virtual-chain method reply's payload: the handler's `Result`, as the wRPC server frames it.
 type VccReply = Result<Serializable<GetVirtualChainFromBlockV2Response>, ServerError>;
 
-/// Rewrites `bytes` with `elide`'s field removed, or `None` if the frame is not a successful
-/// virtual-chain reply.
+/// A `GetBlock` reply's payload, framed the same way.
+type BlockReply = Result<Serializable<GetBlockResponse>, ServerError>;
+
+/// Rewrites `bytes` with `elide`'s field removed, or `None` if the frame is not the successful
+/// reply carrying it.
 fn tamper(bytes: &[u8], elide: Elide, elided: &AtomicUsize) -> Option<Message> {
     let message = BorshServerMessage::<RpcApiOps, Id64>::try_from(bytes).ok()?;
     if !matches!(message.header.kind, ServerMessageKind::Success)
-        || message.header.op != Some(RpcApiOps::GetVirtualChainFromBlockV2)
+        || message.header.op != Some(elide.op())
     {
         return None;
     }
 
     // Only the `Ok` arm carries a response; an error reply is forwarded untouched.
-    let mut response = VccReply::deserialize(&mut &message.payload[..]).ok()?.ok()?.into_inner();
-    elided.fetch_add(elide.apply(&mut response), Ordering::Relaxed);
+    let (payload, count) = elide.apply(message.payload)?;
+    elided.fetch_add(count, Ordering::Relaxed);
 
-    let payload =
-        borsh::to_vec::<VccReply>(&Ok(Serializable(response))).expect("response must reserialize");
     let header =
         BorshServerMessageHeader::new(message.header.id, message.header.kind, message.header.op);
     let rewritten =
@@ -328,8 +371,9 @@ struct Harness {
     _api: ApiGuard,
 }
 
-/// Starts a node, a proxy eliding `elide`, and a bridge connected behind the proxy.
-async fn setup(elide: Elide) -> Harness {
+/// Starts a node, a proxy eliding `elide`, and a bridge behind the proxy that anchors its fresh
+/// chain as `seed_depth` says.
+async fn spawn(elide: Elide, seed_depth: Option<u64>) -> Harness {
     record_panics();
 
     let node = L1Node::new(NetworkId::new(NetworkType::Simnet), None).await;
@@ -338,17 +382,26 @@ async fn setup(elide: Elide) -> Harness {
     let config = L1BridgeConfig::default()
         .with_url(Some(proxy.url()))
         .with_network_type(NetworkType::Simnet)
-        .with_connect_strategy(ConnectStrategy::Fallback);
+        .with_connect_strategy(ConnectStrategy::Fallback)
+        .with_seed_depth(seed_depth);
 
     let sink = RecordingSink::new();
     let (api_tx, api_rx) = mpsc::channel(1);
     let bridge = L1Bridge::new(config, sink.clone(), api_rx);
 
+    Harness { node, bridge, sink, proxy, _api: api_tx }
+}
+
+/// Spawns a harness anchored at the pruning point and waits for it to connect, leaving the sync
+/// path as the only place the elided field is read.
+async fn setup(elide: Elide) -> Harness {
+    let h = spawn(elide, None).await;
+
     // Drain `Connected` so a later `wait_and_pop` parks on the queue, as a consumer would.
-    let events = bridge.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)).await;
+    let events = h.bridge.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)).await;
     assert_eq!(events.len(), 1, "the bridge queued {events:?} before connecting");
 
-    Harness { node, bridge, sink, proxy, _api: api_tx }
+    h
 }
 
 /// Mines until a tampered response reaches the worker, then asserts the bridge reports the
@@ -383,27 +436,47 @@ async fn assert_fatal_on_elided_field(elide: Elide) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_hash_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderHash).await;
+    assert_fatal_on_elided_field(Elide::Chain(ChainField::HeaderHash)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_daa_score_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderDaaScore).await;
+    assert_fatal_on_elided_field(Elide::Chain(ChainField::HeaderDaaScore)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_transaction_storage_mass_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::TxStorageMass).await;
+    assert_fatal_on_elided_field(Elide::Chain(ChainField::TxStorageMass)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_timestamp_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderTimestamp).await;
+    assert_fatal_on_elided_field(Elide::Chain(ChainField::HeaderTimestamp)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn elided_header_blue_score_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::HeaderBlueScore).await;
+    assert_fatal_on_elided_field(Elide::Chain(ChainField::HeaderBlueScore)).await;
+}
+
+/// The walk in `seed_from_recent` reads `verbose_data` before the bridge announces `Connected`, so
+/// a peer eliding it there kills the worker at startup, before any of the sync-path reads above
+/// runs. The walk has no parent to follow and can never yield progress, so the consumer is still
+/// owed `Fatal`, and this is the only case where nothing at all precedes it in the queue.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn elided_block_verbose_data_reports_fatal() {
+    // One step below the sink is enough: the walk's first `get_block` reply carries the field.
+    let h = spawn(Elide::BlockVerboseData, Some(1)).await;
+    h.proxy.wait_for_elision(TIMEOUT).await;
+
+    let event = tokio::time::timeout(FATAL_TIMEOUT, h.bridge.wait_and_pop()).await;
+    assert!(
+        matches!(event, Ok(L1Event::Fatal { .. })),
+        "expected Fatal while seeding below the sink, got {event:?}. The worker panicked at: {:?}",
+        bridge_panics(),
+    );
+
+    h.node.shutdown().await;
 }
 
 // ============================================================================
@@ -418,7 +491,7 @@ async fn elided_header_blue_score_reports_fatal() {
 /// parked forever.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn malformed_response_leaves_the_bridge_observable() {
-    let h = setup(Elide::HeaderDaaScore).await;
+    let h = setup(Elide::Chain(ChainField::HeaderDaaScore)).await;
 
     h.node.mine_blocks(2).await;
     h.proxy.wait_for_elision(TIMEOUT).await;

--- a/l1/bridge/tests/wire_panic_repro.rs
+++ b/l1/bridge/tests/wire_panic_repro.rs
@@ -1,19 +1,21 @@
-//! Reproduction: the bridge worker `expect`/`unwrap`s fields carried on the RPC wire, so a peer
-//! that elides one kills the worker thread with a panic. The worker runs on a bare `thread::spawn`
-//! with no `catch_unwind`, so the panic is not converted into an [`L1Event::Fatal`]: the thread
-//! dies and consumers parked in `wait_and_pop` block forever with no indication.
+//! Reproduction: the bridge worker `expect`/`unwrap`s fields the RPC peer carries as `Option`, so a
+//! peer that elides one panics the worker thread. The worker runs on a bare `thread::spawn` with no
+//! `catch_unwind`, so the panic never becomes an [`L1Event::Fatal`]: the thread dies, the sink stops
+//! advancing, and consumers parked in `wait_and_pop` block forever with no indication.
 //!
-//! Each test drives a real L1 node through a proxy that elides exactly one field from the
-//! `GetVirtualChainFromBlockV2` response, then asserts the bridge surfaces `Fatal`. Every test
-//! fails by timing out, which is the defect: the parked consumer is never woken.
+//! Each test drives a real L1 node through a proxy that elides exactly one field from every
+//! `GetVirtualChainFromBlockV2` response, then asserts the bridge reports the malformed response.
 //!
 //! `L1BridgeConfig::default()` reaches the public community resolver, so the peer serving these
 //! responses is untrusted and this is a remote liveness kill.
 
 use std::{
-    collections::HashSet,
-    sync::{Arc, Mutex},
-    time::Duration,
+    panic,
+    sync::{
+        Arc, Mutex, Once,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
 };
 
 use borsh::BorshDeserialize;
@@ -31,17 +33,53 @@ use vprogs_l1_types::{ChainBlockMetadata, ConnectStrategy, L1Transaction, Networ
 use vprogs_node_test_utils::{L1BridgeExt, L1Node};
 use vprogs_storage_canonical_chain::CanonicalChainManager;
 use workflow_rpc::{
+    error::ServerError,
     id::Id64,
-    messages::borsh::{BorshReqHeader, BorshServerMessage, BorshServerMessageHeader},
+    messages::borsh::{BorshServerMessage, BorshServerMessageHeader, ServerMessageKind},
 };
 use workflow_serializer::prelude::Serializable;
 
-/// Time allowed for the node to start, the bridge to connect, and blocks to reach the sink.
+/// Time allowed for the node to start, the bridge to connect, and a tampered response to be served.
 const TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Time a consumer waits for the `Fatal` the worker owes it after the panic. The worker reaches the
-/// panic within milliseconds of the tampered response, so exceeding this means no event is coming.
+/// Time a consumer waits for the event the worker owes it after the tampered response. The worker
+/// reaches the site within milliseconds of the response, so exceeding this means none is coming.
 const FATAL_TIMEOUT: Duration = Duration::from_secs(15);
+
+// ============================================================================
+// Panic recording
+// ============================================================================
+
+/// Panic reports from every thread in this binary, including the bridge worker's. Each entry
+/// carries the panicking source location, which names the site that consumed the elided field.
+static PANICS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// Installs a hook recording every panic report while keeping the default one. Idempotent.
+fn record_panics() {
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        let default = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            PANICS.lock().expect("panic log poisoned").push(info.to_string());
+            default(info);
+        }));
+    });
+}
+
+/// The recorded panic reports raised at `site`, a `file.rs:line` location under `l1/bridge/src`.
+///
+/// Matching the location rather than the whole report keeps a sibling test's assert text, which
+/// quotes these same sites, out of the result.
+fn panics_at(site: &str) -> Vec<String> {
+    let location = format!("panicked at l1/bridge/src/{site}:");
+    PANICS
+        .lock()
+        .expect("panic log poisoned")
+        .iter()
+        .filter(|p| p.starts_with(&location))
+        .cloned()
+        .collect()
+}
 
 // ============================================================================
 // The tampered field, one per panic site
@@ -57,31 +95,33 @@ enum Elide {
     /// `worker.rs:460` - `header.daa_score.expect("missing daa_score")`.
     HeaderDaaScore,
     /// `worker.rs:470` - `L1Transaction::try_from(tx.clone()).expect("missing tx fields")`.
-    TxMass,
+    TxStorageMass,
     /// `worker.rs:505` - `ChainBlockMetadata::try_from(header).unwrap()`, which also requires
-    /// `timestamp`. Reached only when the fields checked earlier are present.
+    /// `timestamp`. Reached only once the fields checked earlier in the loop are present.
     HeaderTimestamp,
     /// `worker.rs:526` - `header.blue_score.expect("missing blue_score")` in `lane_state`.
     HeaderBlueScore,
 }
 
 impl Elide {
-    /// Removes this variant's field from every chain block in `response`.
-    fn apply(self, response: &mut GetVirtualChainFromBlockV2Response) {
-        for block in response.chain_block_accepted_transactions.iter_mut() {
+    /// Removes this variant's field throughout `response`, returning how many were removed.
+    fn apply(self, response: &mut GetVirtualChainFromBlockV2Response) -> usize {
+        let mut elided = 0;
+        for block in Arc::make_mut(&mut response.chain_block_accepted_transactions) {
             let header = &mut block.chain_block_header;
-            match self {
-                Elide::HeaderHash => header.hash = None,
-                Elide::HeaderDaaScore => header.daa_score = None,
-                Elide::HeaderTimestamp => header.timestamp = None,
-                Elide::HeaderBlueScore => header.blue_score = None,
-                Elide::TxMass => {
-                    for tx in block.accepted_transactions.iter_mut() {
-                        tx.mass = None;
-                    }
-                }
-            }
+            elided += match self {
+                Elide::HeaderHash => header.hash.take().is_some() as usize,
+                Elide::HeaderDaaScore => header.daa_score.take().is_some() as usize,
+                Elide::HeaderTimestamp => header.timestamp.take().is_some() as usize,
+                Elide::HeaderBlueScore => header.blue_score.take().is_some() as usize,
+                Elide::TxStorageMass => block
+                    .accepted_transactions
+                    .iter_mut()
+                    .map(|tx| tx.storage_mass.take().is_some() as usize)
+                    .sum::<usize>(),
+            };
         }
+        elided
     }
 }
 
@@ -91,13 +131,14 @@ impl Elide {
 
 /// A wRPC proxy between the bridge and a real L1 node.
 ///
-/// It forwards every frame verbatim except the responses to `GetVirtualChainFromBlockV2`, from
-/// which it elides one field. Requests carry `BorshReqHeader { id, op }` and responses carry
-/// `BorshServerMessageHeader { id, kind, op }`; the response header's `op` is not populated for
-/// method replies, so the proxy tracks which request ids it must tamper by their op.
+/// It forwards every frame verbatim except successful replies to `GetVirtualChainFromBlockV2`, from
+/// which it elides one field, and counts what it removed so a test can establish that the worker
+/// was actually served a malformed response.
 struct TamperProxy {
     /// URL the bridge connects to, standing in for the node's own wRPC URL.
     url: String,
+    /// Fields removed from responses so far.
+    elided: Arc<AtomicUsize>,
 }
 
 impl TamperProxy {
@@ -105,10 +146,13 @@ impl TamperProxy {
     async fn start(upstream: String, elide: Elide) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("proxy failed to bind");
         let port = listener.local_addr().expect("proxy has no local address").port();
+        let elided = Arc::new(AtomicUsize::new(0));
 
+        let counter = elided.clone();
         tokio::spawn(async move {
             while let Ok((stream, _)) = listener.accept().await {
                 let upstream = upstream.clone();
+                let counter = counter.clone();
                 tokio::spawn(async move {
                     let downstream = tokio_tungstenite::accept_async(stream)
                         .await
@@ -116,17 +160,33 @@ impl TamperProxy {
                     let (node, _) = tokio_tungstenite::connect_async(&upstream)
                         .await
                         .expect("proxy failed to reach the node");
-                    pump(downstream, node, elide).await;
+                    pump(downstream, node, elide, counter).await;
                 });
             }
         });
 
-        Self { url: format!("ws://127.0.0.1:{port}") }
+        Self { url: format!("ws://127.0.0.1:{port}"), elided }
     }
 
     /// The proxy's wRPC URL.
     fn url(&self) -> String {
         self.url.clone()
+    }
+
+    /// Waits until the proxy has removed a field from a response the node actually served.
+    ///
+    /// Every later assert is about how the worker handles that response, so reaching it without a
+    /// single elision would make those asserts say nothing about the sites they name.
+    async fn wait_for_elision(&self, timeout: Duration) {
+        let start = Instant::now();
+        while self.elided.load(Ordering::Relaxed) == 0 {
+            assert!(
+                start.elapsed() <= timeout,
+                "the proxy elided no field, so no tampered response ever reached the worker and \
+                 this test would prove nothing about the site it names",
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 }
 
@@ -135,24 +195,15 @@ async fn pump(
     downstream: WebSocketStream<TcpStream>,
     upstream: WebSocketStream<MaybeTlsStream<TcpStream>>,
     elide: Elide,
+    elided: Arc<AtomicUsize>,
 ) {
     let (mut down_tx, mut down_rx) = downstream.split();
     let (mut up_tx, mut up_rx) = upstream.split();
 
-    // Ids of in-flight virtual-chain requests, recorded on the way out and consumed on the way
-    // back. Shared because the two directions are pumped concurrently.
-    let pending: Arc<Mutex<HashSet<Id64>>> = Arc::new(Mutex::new(HashSet::new()));
-
-    let to_node = {
-        let pending = pending.clone();
-        async move {
-            while let Some(Ok(msg)) = down_rx.next().await {
-                if let Message::Binary(bytes) = &msg {
-                    record_virtual_chain_request(bytes, &pending);
-                }
-                if up_tx.send(msg).await.is_err() {
-                    return;
-                }
+    let to_node = async move {
+        while let Some(Ok(msg)) = down_rx.next().await {
+            if up_tx.send(msg).await.is_err() {
+                return;
             }
         }
     };
@@ -160,7 +211,7 @@ async fn pump(
     let to_client = async move {
         while let Some(Ok(msg)) = up_rx.next().await {
             let msg = match &msg {
-                Message::Binary(bytes) => tamper(bytes, &pending, elide).unwrap_or(msg),
+                Message::Binary(bytes) => tamper(bytes, elide, &elided).unwrap_or(msg),
                 _ => msg,
             };
             if down_tx.send(msg).await.is_err() {
@@ -174,37 +225,27 @@ async fn pump(
     futures::future::select(to_node, to_client).await;
 }
 
-/// Records `bytes`' request id if it is a virtual-chain request, so its reply can be tampered.
-fn record_virtual_chain_request(bytes: &[u8], pending: &Mutex<HashSet<Id64>>) {
-    let header = match BorshReqHeader::<RpcApiOps, Id64>::deserialize(&mut &bytes[..]) {
-        Ok(header) => header,
-        Err(_) => return,
-    };
-    if header.op != RpcApiOps::GetVirtualChainFromBlockV2 {
-        return;
-    }
-    if let Some(id) = header.id {
-        pending.lock().expect("pending set poisoned").insert(id);
-    }
-}
+/// A virtual-chain method reply's payload: the handler's `Result`, as the wRPC server frames it.
+type VccReply = Result<Serializable<GetVirtualChainFromBlockV2Response>, ServerError>;
 
-/// Rewrites `bytes` with the field elided, or `None` if the frame is not a virtual-chain response.
-fn tamper(bytes: &[u8], pending: &Mutex<HashSet<Id64>>, elide: Elide) -> Option<Message> {
+/// Rewrites `bytes` with `elide`'s field removed, or `None` if the frame is not a successful
+/// virtual-chain reply.
+fn tamper(bytes: &[u8], elide: Elide, elided: &AtomicUsize) -> Option<Message> {
     let message = BorshServerMessage::<RpcApiOps, Id64>::try_from(bytes).ok()?;
-    let id = message.header.id?;
-    if !pending.lock().expect("pending set poisoned").remove(&id) {
+    if !matches!(message.header.kind, ServerMessageKind::Success)
+        || message.header.op != Some(RpcApiOps::GetVirtualChainFromBlockV2)
+    {
         return None;
     }
 
-    // A tracked id whose payload does not decode is an error reply, which is passed through.
-    let mut response =
-        Serializable::<GetVirtualChainFromBlockV2Response>::deserialize(&mut &message.payload[..])
-            .ok()?
-            .into_inner();
-    elide.apply(&mut response);
+    // Only the `Ok` arm carries a response; an error reply is forwarded untouched.
+    let mut response = VccReply::deserialize(&mut &message.payload[..]).ok()?.ok()?.into_inner();
+    elided.fetch_add(elide.apply(&mut response), Ordering::Relaxed);
 
-    let payload = borsh::to_vec(&Serializable(response)).expect("response must reserialize");
-    let header = BorshServerMessageHeader::new(message.header.id, message.header.kind, message.header.op);
+    let payload = borsh::to_vec::<VccReply>(&Ok(Serializable(response)))
+        .expect("response must reserialize");
+    let header =
+        BorshServerMessageHeader::new(message.header.id, message.header.kind, message.header.op);
     let rewritten =
         BorshServerMessage::new(header, &payload).try_to_vec().expect("frame must reserialize");
     Some(Message::Binary(rewritten))
@@ -281,8 +322,19 @@ impl ChainSink<ChainBlockMetadata, L1Transaction> for RecordingSink {
 /// Keeps the API command channel's sender alive so the worker's command branch stays open.
 type ApiGuard = mpsc::Sender<Command<RecordingSink>>;
 
-/// Starts a node, a proxy eliding `elide`, and a connected bridge behind the proxy.
-async fn setup(elide: Elide) -> (L1Node, L1Bridge, RecordingSink, ApiGuard) {
+/// A node, a proxy eliding one field in front of it, and a bridge connected through the proxy.
+struct Harness {
+    node: L1Node,
+    bridge: L1Bridge,
+    sink: RecordingSink,
+    proxy: TamperProxy,
+    _api: ApiGuard,
+}
+
+/// Starts a node, a proxy eliding `elide`, and a bridge connected behind the proxy.
+async fn setup(elide: Elide) -> Harness {
+    record_panics();
+
     let node = L1Node::new(NetworkId::new(NetworkType::Simnet), None).await;
     let proxy = TamperProxy::start(node.wrpc_borsh_url(), elide).await;
 
@@ -296,32 +348,36 @@ async fn setup(elide: Elide) -> (L1Node, L1Bridge, RecordingSink, ApiGuard) {
     let bridge = L1Bridge::new(config, sink.clone(), api_rx);
 
     // Drain `Connected` so a later `wait_and_pop` parks on the queue, as a consumer would.
-    bridge.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)).await;
+    let events = bridge.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)).await;
+    assert_eq!(events.len(), 1, "the bridge queued {events:?} before connecting");
 
-    (node, bridge, sink, api_tx)
+    Harness { node, bridge, sink, proxy, _api: api_tx }
 }
 
-/// Mines a block whose tampered response reaches the worker, then asserts the bridge reports the
+/// Mines until a tampered response reaches the worker, then asserts the bridge reports the
 /// malformed response as `Fatal`.
 ///
-/// The bridge owes every consumer either progress or a terminal event. Panicking on the worker
-/// thread delivers neither.
+/// The bridge owes every consumer either progress or a terminal event. A peer that elides a
+/// required field can never yield progress, so `Fatal` is the only outcome left. Panicking on the
+/// worker thread delivers neither.
 async fn assert_fatal_on_elided_field(elide: Elide, site: &str) {
-    let (node, bridge, sink, _api) = setup(elide).await;
+    let h = setup(elide).await;
 
-    // Two blocks: Kaspa accepts a block's transactions on the next chain block, so the second
-    // makes the first's txs (and header) land in a virtual-chain response the proxy tampers.
-    node.mine_blocks(2).await;
+    // Kaspa accepts a block's transactions on the next chain block, so the second block puts the
+    // first's header and transactions into a virtual-chain response the proxy tampers.
+    h.node.mine_blocks(2).await;
+    h.proxy.wait_for_elision(TIMEOUT).await;
 
-    let event = tokio::time::timeout(FATAL_TIMEOUT, bridge.wait_and_pop()).await;
+    let event = tokio::time::timeout(FATAL_TIMEOUT, h.bridge.wait_and_pop()).await;
     assert!(
         matches!(event, Ok(L1Event::Fatal { .. })),
-        "{site}: expected Fatal on the elided field, got {event:?} \
-         (worker scheduled {} blocks before dying)",
-        sink.scheduled(),
+        "{site}: expected Fatal on the elided field, got {event:?}. The worker scheduled {} \
+         blocks, and panicked at: {:?}",
+        h.sink.scheduled(),
+        panics_at(site),
     );
 
-    node.shutdown().await;
+    h.node.shutdown().await;
 }
 
 // ============================================================================
@@ -329,71 +385,70 @@ async fn assert_fatal_on_elided_field(elide: Elide, site: &str) {
 // ============================================================================
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: worker.rs:459 panics on an elided header hash, killing the thread with no Fatal"]
 async fn elided_header_hash_reports_fatal() {
     assert_fatal_on_elided_field(Elide::HeaderHash, "worker.rs:459").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: worker.rs:460 panics on an elided daa_score, killing the thread with no Fatal"]
 async fn elided_header_daa_score_reports_fatal() {
     assert_fatal_on_elided_field(Elide::HeaderDaaScore, "worker.rs:460").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: worker.rs:470 panics on an elided tx field, killing the thread with no Fatal"]
-async fn elided_transaction_field_reports_fatal() {
-    assert_fatal_on_elided_field(Elide::TxMass, "worker.rs:470").await;
+async fn elided_transaction_storage_mass_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::TxStorageMass, "worker.rs:470").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: worker.rs:505 panics on an elided timestamp, killing the thread with no Fatal"]
 async fn elided_header_timestamp_reports_fatal() {
     assert_fatal_on_elided_field(Elide::HeaderTimestamp, "worker.rs:505").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: worker.rs:526 panics on an elided blue_score, killing the thread with no Fatal"]
 async fn elided_header_blue_score_reports_fatal() {
     assert_fatal_on_elided_field(Elide::HeaderBlueScore, "worker.rs:526").await;
 }
 
 // `worker.rs:543` (`header.daa_score.expect("missing daa_score")` in `lane_state`) has no case of
-// its own: it reads the same `Option` on the same header that `worker.rs:460` already unwrapped
-// earlier in the loop, so any response that would trip it trips `:460` first. It is unreachable
-// while `:460` stands, and `elided_header_daa_score_reports_fatal` covers the field.
+// its own, and no response can give it one. It reads the same `Option` on the same header that
+// `worker.rs:460` unwraps earlier in the same loop iteration, so every response that would trip it
+// trips `:460` first. `elided_header_daa_score_reports_fatal` covers the field; a fix to `:543`
+// alone is unobservable, and a fix to `:460` alone leaves `:543` reachable and must be checked by
+// review rather than by this test.
 
 // ============================================================================
 // The consequence: a dead worker and a parked consumer
 // ============================================================================
 
-/// Verifies the worker survives a malformed response well enough to keep serving the chain, or
-/// else reports that it cannot.
+/// Verifies the bridge stays observable after a malformed response: it either keeps scheduling or
+/// says why it stopped.
 ///
-/// After the panic the thread is gone: no further block is ever scheduled and no event is ever
-/// queued, so a consumer in `wait_and_pop` parks forever. Nothing observable distinguishes this
-/// from a quiet chain.
+/// After the panic the worker thread is gone, so no further block is scheduled and no event is ever
+/// queued. Nothing observable distinguishes that from a quiet chain, and a consumer in
+/// `wait_and_pop` parks forever.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "repro: the panicked worker thread dies silently, freezing the sink and parking consumers"]
-async fn worker_survives_or_reports_a_malformed_response() {
-    let (node, bridge, sink, _api) = setup(Elide::HeaderDaaScore).await;
+async fn malformed_response_leaves_the_bridge_observable() {
+    let h = setup(Elide::HeaderDaaScore).await;
 
-    node.mine_blocks(2).await;
+    h.node.mine_blocks(2).await;
+    h.proxy.wait_for_elision(TIMEOUT).await;
 
-    // Give the worker time to reach the tampered response and die.
+    // Let the worker reach the tampered response.
     tokio::time::sleep(Duration::from_secs(5)).await;
-    let scheduled_at_death = sink.scheduled();
+    let scheduled_before = h.sink.scheduled();
 
-    // Keep mining: a live worker would schedule these.
-    node.mine_blocks(5).await;
+    // Keep mining: a live worker schedules these.
+    h.node.mine_blocks(5).await;
     tokio::time::sleep(Duration::from_secs(5)).await;
 
+    let progressed = h.sink.scheduled() > scheduled_before;
+    let events = h.bridge.drain();
     assert!(
-        sink.scheduled() > scheduled_at_death,
-        "worker stopped scheduling after the malformed response (stuck at {scheduled_at_death} \
-         blocks) and queued no event to say so: {:?}",
-        bridge.drain(),
+        progressed || !events.is_empty(),
+        "after the malformed response the bridge neither scheduled a block (stuck at \
+         {scheduled_before}) nor queued an event to say why; its worker panicked at: {:?}",
+        panics_at("worker.rs:460"),
     );
 
-    node.shutdown().await;
+    h.node.shutdown().await;
 }

--- a/l1/bridge/tests/wire_panic_repro.rs
+++ b/l1/bridge/tests/wire_panic_repro.rs
@@ -1,0 +1,399 @@
+//! Reproduction: the bridge worker `expect`/`unwrap`s fields carried on the RPC wire, so a peer
+//! that elides one kills the worker thread with a panic. The worker runs on a bare `thread::spawn`
+//! with no `catch_unwind`, so the panic is not converted into an [`L1Event::Fatal`]: the thread
+//! dies and consumers parked in `wait_and_pop` block forever with no indication.
+//!
+//! Each test drives a real L1 node through a proxy that elides exactly one field from the
+//! `GetVirtualChainFromBlockV2` response, then asserts the bridge surfaces `Fatal`. Every test
+//! fails by timing out, which is the defect: the parked consumer is never woken.
+//!
+//! `L1BridgeConfig::default()` reaches the public community resolver, so the peer serving these
+//! responses is untrusted and this is a remote liveness kill.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use borsh::BorshDeserialize;
+use futures::{SinkExt, StreamExt};
+use kaspa_consensus_core::network::NetworkId;
+use kaspa_rpc_core::{GetVirtualChainFromBlockV2Response, api::ops::RpcApiOps};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
+use vprogs_core_types::{ChainSink, SchedulerTransaction};
+use vprogs_l1_bridge::{Command, L1Bridge, L1BridgeConfig, L1Event};
+use vprogs_l1_types::{ChainBlockMetadata, ConnectStrategy, L1Transaction, NetworkType};
+use vprogs_node_test_utils::{L1BridgeExt, L1Node};
+use vprogs_storage_canonical_chain::CanonicalChainManager;
+use workflow_rpc::{
+    id::Id64,
+    messages::borsh::{BorshReqHeader, BorshServerMessage, BorshServerMessageHeader},
+};
+use workflow_serializer::prelude::Serializable;
+
+/// Time allowed for the node to start, the bridge to connect, and blocks to reach the sink.
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Time a consumer waits for the `Fatal` the worker owes it after the panic. The worker reaches the
+/// panic within milliseconds of the tampered response, so exceeding this means no event is coming.
+const FATAL_TIMEOUT: Duration = Duration::from_secs(15);
+
+// ============================================================================
+// The tampered field, one per panic site
+// ============================================================================
+
+/// A single field elided from every `GetVirtualChainFromBlockV2` response, named for the worker
+/// site that consumes it without checking. An honest node at `Full` verbosity always populates
+/// these; a malicious one is free not to.
+#[derive(Clone, Copy, Debug)]
+enum Elide {
+    /// `worker.rs:459` - `header.hash.expect("missing hash")`.
+    HeaderHash,
+    /// `worker.rs:460` - `header.daa_score.expect("missing daa_score")`.
+    HeaderDaaScore,
+    /// `worker.rs:470` - `L1Transaction::try_from(tx.clone()).expect("missing tx fields")`.
+    TxMass,
+    /// `worker.rs:505` - `ChainBlockMetadata::try_from(header).unwrap()`, which also requires
+    /// `timestamp`. Reached only when the fields checked earlier are present.
+    HeaderTimestamp,
+    /// `worker.rs:526` - `header.blue_score.expect("missing blue_score")` in `lane_state`.
+    HeaderBlueScore,
+}
+
+impl Elide {
+    /// Removes this variant's field from every chain block in `response`.
+    fn apply(self, response: &mut GetVirtualChainFromBlockV2Response) {
+        for block in response.chain_block_accepted_transactions.iter_mut() {
+            let header = &mut block.chain_block_header;
+            match self {
+                Elide::HeaderHash => header.hash = None,
+                Elide::HeaderDaaScore => header.daa_score = None,
+                Elide::HeaderTimestamp => header.timestamp = None,
+                Elide::HeaderBlueScore => header.blue_score = None,
+                Elide::TxMass => {
+                    for tx in block.accepted_transactions.iter_mut() {
+                        tx.mass = None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tampering wRPC proxy
+// ============================================================================
+
+/// A wRPC proxy between the bridge and a real L1 node.
+///
+/// It forwards every frame verbatim except the responses to `GetVirtualChainFromBlockV2`, from
+/// which it elides one field. Requests carry `BorshReqHeader { id, op }` and responses carry
+/// `BorshServerMessageHeader { id, kind, op }`; the response header's `op` is not populated for
+/// method replies, so the proxy tracks which request ids it must tamper by their op.
+struct TamperProxy {
+    /// URL the bridge connects to, standing in for the node's own wRPC URL.
+    url: String,
+}
+
+impl TamperProxy {
+    /// Binds a proxy in front of `upstream` and serves connections until the test ends.
+    async fn start(upstream: String, elide: Elide) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("proxy failed to bind");
+        let port = listener.local_addr().expect("proxy has no local address").port();
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let upstream = upstream.clone();
+                tokio::spawn(async move {
+                    let downstream = tokio_tungstenite::accept_async(stream)
+                        .await
+                        .expect("proxy failed the client handshake");
+                    let (node, _) = tokio_tungstenite::connect_async(&upstream)
+                        .await
+                        .expect("proxy failed to reach the node");
+                    pump(downstream, node, elide).await;
+                });
+            }
+        });
+
+        Self { url: format!("ws://127.0.0.1:{port}") }
+    }
+
+    /// The proxy's wRPC URL.
+    fn url(&self) -> String {
+        self.url.clone()
+    }
+}
+
+/// Relays frames both ways, eliding a field from every virtual-chain response.
+async fn pump(
+    downstream: WebSocketStream<TcpStream>,
+    upstream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    elide: Elide,
+) {
+    let (mut down_tx, mut down_rx) = downstream.split();
+    let (mut up_tx, mut up_rx) = upstream.split();
+
+    // Ids of in-flight virtual-chain requests, recorded on the way out and consumed on the way
+    // back. Shared because the two directions are pumped concurrently.
+    let pending: Arc<Mutex<HashSet<Id64>>> = Arc::new(Mutex::new(HashSet::new()));
+
+    let to_node = {
+        let pending = pending.clone();
+        async move {
+            while let Some(Ok(msg)) = down_rx.next().await {
+                if let Message::Binary(bytes) = &msg {
+                    record_virtual_chain_request(bytes, &pending);
+                }
+                if up_tx.send(msg).await.is_err() {
+                    return;
+                }
+            }
+        }
+    };
+
+    let to_client = async move {
+        while let Some(Ok(msg)) = up_rx.next().await {
+            let msg = match &msg {
+                Message::Binary(bytes) => tamper(bytes, &pending, elide).unwrap_or(msg),
+                _ => msg,
+            };
+            if down_tx.send(msg).await.is_err() {
+                return;
+            }
+        }
+    };
+
+    // Either direction closing tears the connection down.
+    futures::pin_mut!(to_node, to_client);
+    futures::future::select(to_node, to_client).await;
+}
+
+/// Records `bytes`' request id if it is a virtual-chain request, so its reply can be tampered.
+fn record_virtual_chain_request(bytes: &[u8], pending: &Mutex<HashSet<Id64>>) {
+    let header = match BorshReqHeader::<RpcApiOps, Id64>::deserialize(&mut &bytes[..]) {
+        Ok(header) => header,
+        Err(_) => return,
+    };
+    if header.op != RpcApiOps::GetVirtualChainFromBlockV2 {
+        return;
+    }
+    if let Some(id) = header.id {
+        pending.lock().expect("pending set poisoned").insert(id);
+    }
+}
+
+/// Rewrites `bytes` with the field elided, or `None` if the frame is not a virtual-chain response.
+fn tamper(bytes: &[u8], pending: &Mutex<HashSet<Id64>>, elide: Elide) -> Option<Message> {
+    let message = BorshServerMessage::<RpcApiOps, Id64>::try_from(bytes).ok()?;
+    let id = message.header.id?;
+    if !pending.lock().expect("pending set poisoned").remove(&id) {
+        return None;
+    }
+
+    // A tracked id whose payload does not decode is an error reply, which is passed through.
+    let mut response =
+        Serializable::<GetVirtualChainFromBlockV2Response>::deserialize(&mut &message.payload[..])
+            .ok()?
+            .into_inner();
+    elide.apply(&mut response);
+
+    let payload = borsh::to_vec(&Serializable(response)).expect("response must reserialize");
+    let header = BorshServerMessageHeader::new(message.header.id, message.header.kind, message.header.op);
+    let rewritten =
+        BorshServerMessage::new(header, &payload).try_to_vec().expect("frame must reserialize");
+    Some(Message::Binary(rewritten))
+}
+
+// ============================================================================
+// Sink
+// ============================================================================
+
+/// A [`ChainSink`] over a real [`CanonicalChainManager`], recording what the bridge schedules.
+#[derive(Clone)]
+struct RecordingSink(Arc<Mutex<SinkInner>>);
+
+struct SinkInner {
+    /// The canonical chain the bridge drives, providing the ids/metadata it reads back.
+    manager: CanonicalChainManager<ChainBlockMetadata>,
+    /// How many blocks the bridge has scheduled.
+    scheduled: usize,
+}
+
+impl RecordingSink {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(SinkInner {
+            manager: CanonicalChainManager::default(),
+            scheduled: 0,
+        })))
+    }
+
+    /// How many blocks the bridge has scheduled so far.
+    fn scheduled(&self) -> usize {
+        self.0.lock().expect("sink poisoned").scheduled
+    }
+}
+
+impl ChainSink<ChainBlockMetadata, L1Transaction> for RecordingSink {
+    fn append(
+        &mut self,
+        metadata: ChainBlockMetadata,
+        _txs: Vec<SchedulerTransaction<L1Transaction>>,
+    ) -> u64 {
+        let mut inner = self.0.lock().expect("sink poisoned");
+        let id = inner.manager.append(metadata).id;
+        inner.scheduled += 1;
+        id
+    }
+
+    fn rollback(&mut self, new_tip: u64) {
+        self.0.lock().expect("sink poisoned").manager.rollback(new_tip);
+    }
+
+    fn finalize(&mut self, below: u64) {
+        self.0.lock().expect("sink poisoned").manager.finalize(below);
+    }
+
+    fn tip(&self) -> u64 {
+        self.0.lock().expect("sink poisoned").manager.chain().tip()
+    }
+
+    fn metadata(&self, id: u64) -> Option<ChainBlockMetadata> {
+        self.0.lock().expect("sink poisoned").manager.metadata(id).copied()
+    }
+
+    fn id(&self, block_hash: &[u8; 32]) -> Option<u64> {
+        self.0.lock().expect("sink poisoned").manager.id(block_hash)
+    }
+
+    fn shutdown(self) {}
+}
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+/// Keeps the API command channel's sender alive so the worker's command branch stays open.
+type ApiGuard = mpsc::Sender<Command<RecordingSink>>;
+
+/// Starts a node, a proxy eliding `elide`, and a connected bridge behind the proxy.
+async fn setup(elide: Elide) -> (L1Node, L1Bridge, RecordingSink, ApiGuard) {
+    let node = L1Node::new(NetworkId::new(NetworkType::Simnet), None).await;
+    let proxy = TamperProxy::start(node.wrpc_borsh_url(), elide).await;
+
+    let config = L1BridgeConfig::default()
+        .with_url(Some(proxy.url()))
+        .with_network_type(NetworkType::Simnet)
+        .with_connect_strategy(ConnectStrategy::Fallback);
+
+    let sink = RecordingSink::new();
+    let (api_tx, api_rx) = mpsc::channel(1);
+    let bridge = L1Bridge::new(config, sink.clone(), api_rx);
+
+    // Drain `Connected` so a later `wait_and_pop` parks on the queue, as a consumer would.
+    bridge.wait_for(TIMEOUT, |e| matches!(e, L1Event::Connected)).await;
+
+    (node, bridge, sink, api_tx)
+}
+
+/// Mines a block whose tampered response reaches the worker, then asserts the bridge reports the
+/// malformed response as `Fatal`.
+///
+/// The bridge owes every consumer either progress or a terminal event. Panicking on the worker
+/// thread delivers neither.
+async fn assert_fatal_on_elided_field(elide: Elide, site: &str) {
+    let (node, bridge, sink, _api) = setup(elide).await;
+
+    // Two blocks: Kaspa accepts a block's transactions on the next chain block, so the second
+    // makes the first's txs (and header) land in a virtual-chain response the proxy tampers.
+    node.mine_blocks(2).await;
+
+    let event = tokio::time::timeout(FATAL_TIMEOUT, bridge.wait_and_pop()).await;
+    assert!(
+        matches!(event, Ok(L1Event::Fatal { .. })),
+        "{site}: expected Fatal on the elided field, got {event:?} \
+         (worker scheduled {} blocks before dying)",
+        sink.scheduled(),
+    );
+
+    node.shutdown().await;
+}
+
+// ============================================================================
+// One case per panic site
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: worker.rs:459 panics on an elided header hash, killing the thread with no Fatal"]
+async fn elided_header_hash_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::HeaderHash, "worker.rs:459").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: worker.rs:460 panics on an elided daa_score, killing the thread with no Fatal"]
+async fn elided_header_daa_score_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::HeaderDaaScore, "worker.rs:460").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: worker.rs:470 panics on an elided tx field, killing the thread with no Fatal"]
+async fn elided_transaction_field_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::TxMass, "worker.rs:470").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: worker.rs:505 panics on an elided timestamp, killing the thread with no Fatal"]
+async fn elided_header_timestamp_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::HeaderTimestamp, "worker.rs:505").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: worker.rs:526 panics on an elided blue_score, killing the thread with no Fatal"]
+async fn elided_header_blue_score_reports_fatal() {
+    assert_fatal_on_elided_field(Elide::HeaderBlueScore, "worker.rs:526").await;
+}
+
+// `worker.rs:543` (`header.daa_score.expect("missing daa_score")` in `lane_state`) has no case of
+// its own: it reads the same `Option` on the same header that `worker.rs:460` already unwrapped
+// earlier in the loop, so any response that would trip it trips `:460` first. It is unreachable
+// while `:460` stands, and `elided_header_daa_score_reports_fatal` covers the field.
+
+// ============================================================================
+// The consequence: a dead worker and a parked consumer
+// ============================================================================
+
+/// Verifies the worker survives a malformed response well enough to keep serving the chain, or
+/// else reports that it cannot.
+///
+/// After the panic the thread is gone: no further block is ever scheduled and no event is ever
+/// queued, so a consumer in `wait_and_pop` parks forever. Nothing observable distinguishes this
+/// from a quiet chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "repro: the panicked worker thread dies silently, freezing the sink and parking consumers"]
+async fn worker_survives_or_reports_a_malformed_response() {
+    let (node, bridge, sink, _api) = setup(Elide::HeaderDaaScore).await;
+
+    node.mine_blocks(2).await;
+
+    // Give the worker time to reach the tampered response and die.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let scheduled_at_death = sink.scheduled();
+
+    // Keep mining: a live worker would schedule these.
+    node.mine_blocks(5).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    assert!(
+        sink.scheduled() > scheduled_at_death,
+        "worker stopped scheduling after the malformed response (stuck at {scheduled_at_death} \
+         blocks) and queued no event to say so: {:?}",
+        bridge.drain(),
+    );
+
+    node.shutdown().await;
+}


### PR DESCRIPTION
Closes #115.

## Problem

`BridgeWorker::fetch_chain_updates` and `lane_state` `expect`/`unwrap`ed fields the wRPC peer carries as `Option` (`hash`, `daa_score`, `blue_score`, `timestamp`, and the transaction's `storage_mass`). The worker runs on a bare `thread::spawn`, so a peer eliding one field panicked the worker thread with no `L1Event::Fatal`: the sink froze and consumers parked in `wait_and_pop` blocked forever, indistinguishable from a quiet chain. `L1BridgeConfig::default()` reaches the public community resolver, so the peer is untrusted and one elided field was a remote liveness kill.

## Fix

- New fatal `Error::MalformedResponse` variant. It is mapped explicitly rather than through the existing `From<RpcError>` conversion, which would classify it as recoverable `Error::Rpc` and log-and-retry a peer that can never serve a usable response (still a silent hang).
- `fetch_chain_updates` validates each chain-block header once up front via the existing `ChainBlockMetadata::try_from` (which already checks all five required header fields) and propagates `MalformedResponse` for elided header or transaction fields. The error flows through `handle_sync_result` into `L1Event::Fatal`, waking parked consumers.
- `lane_state` now takes the validated `ChainBlockMetadata` instead of the raw wire header, so its own `Option` reads (including the unreachable `daa_score` one the issue flagged for review) are gone structurally.
- `seed_from_recent`'s selected-parent walk returns `MalformedResponse` instead of `expect`ing `verbose_data`. That one runs during chain init, before `L1Event::Connected` is pushed, so the panic left a consumer with no event at all; `handle_connected` already routes chain-init errors into `Fatal`. The other two `get_block` calls read only the non-optional `.header`.

## Tests

The wire-panic repros (first two commits) become malformed-response contract tests, renamed to `malformed_response.rs`: a tampering wRPC proxy in front of a real simnet node elides one field per case, and each case asserts `wait_and_pop` returns `L1Event::Fatal`. The proxy picks the reply it rewrites from the field under test, so the seed case elides `verbose_data` from a `GetBlock` reply and spawns its harness without waiting for `Connected`. Each case fails with `Err(Elapsed)` before the fix; all 7 pass after (in ~12s instead of ~97s, since `Fatal` fires immediately). Bridge suite: 13/13. Workspace check and clippy clean.

Follow-up (#123, from review): `MalformedResponse` is terminal, so a byzantine peer handed out by the public resolver can end the bridge for good where rotating to another peer would preserve liveness. Validation happens before any append, so the sink prefix stays consistent and a resync from tip would continue cleanly. Left as-is here; the hardening run owns it.
