### PR TITLE
snapshot-restore (3/4): streaming restore into a fresh store + L1 validation

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -6,7 +6,8 @@
 //! transactions.
 //!
 //! With no subcommand, `vprun` runs the daemon directly from its flags (back-compat with earlier
-//! releases). `vprun snapshot save` instead exports the local node's L2 state to a file.
+//! releases). `vprun snapshot save` exports the local node's L2 state to a file; `vprun snapshot
+//! restore` seeds a fresh data dir from one after confirming it against local L1.
 //!
 //! Supply the fee / bootstrap key through `VPRUN_PRIVATE_KEY` or the config file; `--private-key`
 //! leaks it into shell history and every `ps` listing, so keep that form for throwaway dev keys.
@@ -28,7 +29,7 @@ struct Cli {
 /// Subcommands beyond the default daemon run.
 #[derive(clap::Subcommand)]
 enum Command {
-    /// Save or (later) restore L2 state snapshots.
+    /// Save or restore L2 state snapshots.
     Snapshot {
         #[command(subcommand)]
         action: SnapshotAction,
@@ -46,6 +47,21 @@ enum SnapshotAction {
         /// Path to write the snapshot file to.
         #[arg(long)]
         out: std::path::PathBuf,
+    },
+    /// Restore L2 state from a snapshot file into a fresh data dir, validating against local L1.
+    Restore {
+        /// RocksDB + state-file directory to seed. Must not already hold a store or identity.
+        #[arg(long)]
+        data_dir: std::path::PathBuf,
+        /// Path to the snapshot file to restore from.
+        #[arg(long)]
+        snapshot: std::path::PathBuf,
+        /// Borsh wRPC URL of the local node to confirm the snapshot's settlement against.
+        #[arg(long)]
+        wrpc_url: String,
+        /// Kaspa network: `mainnet` | `testnet-N` | `tn10` | `devnet` | `simnet`.
+        #[arg(long, default_value = "testnet-10")]
+        network: String,
     },
 }
 
@@ -153,6 +169,37 @@ async fn main() {
                 }
                 Err(e) => {
                     eprintln!("snapshot save failed: {e}");
+                    std::process::exit(2);
+                }
+            }
+        }
+        Some(Command::Snapshot {
+            action: SnapshotAction::Restore { data_dir, snapshot, wrpc_url, network },
+        }) => {
+            let network_id = match vprogs_runner::parse_network(&network) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("vprun: configuration error: {e}");
+                    std::process::exit(2);
+                }
+            };
+            match vprogs_runner::snapshot::restore::restore_snapshot(
+                &data_dir, &snapshot, &wrpc_url, network_id,
+            )
+            .await
+            {
+                Ok(s) => {
+                    eprintln!(
+                        "restored {} records at index {}; run `vprun --data-dir {} ...` to resume \
+                         from {}",
+                        s.record_count,
+                        s.committed_index,
+                        data_dir.display(),
+                        s.resume_from
+                    );
+                }
+                Err(e) => {
+                    eprintln!("snapshot restore failed: {e}");
                     std::process::exit(2);
                 }
             }

--- a/runner/src/snapshot.rs
+++ b/runner/src/snapshot.rs
@@ -1,5 +1,6 @@
-//! Snapshot save (and, in a later branch, restore) for bringing up a fresh node past pruning.
+//! Snapshot save and restore for bringing up a fresh node past pruning.
 pub mod header;
+pub mod restore;
 pub mod save;
 
 pub use header::SnapshotHeader;

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -2,14 +2,10 @@
 //! after confirming (both internally and against the local L1 node) that the snapshot's pinned
 //! settlement is genuine.
 //!
-//! [`restore_into_store`] never buffers the whole snapshot: it streams each record straight into
-//! `data` + `latest_ptr` AND feeds it to a [`StreamingBuilder`] in the same pass, committing in
-//! bounded chunks. The builder retains only a bounded spine of not-yet-finalized SMT subtrees (see
-//! `vprogs_core_smt::builder`), so its writes land in the very same write-batch as the record's
-//! `data`/`latest_ptr` writes with no separate accumulation step. The root is sealed and checked
-//! against the pinned settlement root at EOF, in the final write-batch, before anything is written
-//! that would make the store look resumable; any failure after the store has been opened drops the
-//! freshly written column families, since the fresh data dir is exclusively ours at that point.
+//! [`restore_into_store`] streams the snapshot without ever buffering the whole file, and seals and
+//! checks the rebuilt state root against the pinned settlement before writing anything that would
+//! make the store look resumable. Any failure after the store is opened discards the freshly
+//! written data, so a rejected snapshot never leaves a partial store behind.
 
 use std::{io::Read, path::Path};
 
@@ -21,7 +17,7 @@ use vprogs_l1_types::{Hash, L1Transaction, L1TransactionCovenantExt, NetworkId, 
 use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_state_ptr_latest::StatePtrLatest;
-use vprogs_state_snapshot::{SnapshotFormat, SnapshotReader};
+use vprogs_state_snapshot::{Record, SnapshotFormat, SnapshotReader};
 use vprogs_state_version::StateVersion;
 use vprogs_storage_rocksdb_store::{DefaultConfig, RocksDbStore};
 use vprogs_storage_types::Store;
@@ -66,9 +62,9 @@ pub enum RestoreError {
     Io(#[from] std::io::Error),
 }
 
-/// Drops `store` and deletes the just-written `db_path`. Called only on a failure path after
-/// [`RocksDbStore::open`] has created a fresh directory exclusively ours, so a failed restore
-/// never leaves a partially written (but not-yet-verified) store behind.
+/// Drops `store` and deletes the just-written `db_path`. The restore owns this fresh directory
+/// exclusively, so discarding it on failure never leaves a partial store behind and never clobbers
+/// a pre-existing one.
 fn discard_store(store: RocksDbStore<DefaultConfig>, db_path: &Path) {
     drop(store);
     let _ = std::fs::remove_dir_all(db_path);
@@ -77,8 +73,8 @@ fn discard_store(store: RocksDbStore<DefaultConfig>, db_path: &Path) {
 /// Streams `reader`'s records into a fresh store at `data_dir`, verifies the rebuilt SMT root
 /// against `header`'s pinned settlement, and only then writes the cursor (batch metadata, `metas`,
 /// and identity) that makes the store look like a node already committed up to the settlement
-/// block. Caller MUST have validated the snapshot against L1 first (see `validate_against_l1`);
-/// this function only re-confirms the file's own internal consistency.
+/// block. Caller MUST have validated the snapshot against L1 first; this function only re-confirms
+/// the file's own internal consistency.
 ///
 /// Generic over the framing identity `F`: a caller pins a concrete [`SnapshotFormat`] (e.g.
 /// `VpsnapFormat`) when it builds the `SnapshotReader` passed in here.
@@ -106,7 +102,7 @@ pub fn restore_into_store<R: Read, H: Hasher, F: SnapshotFormat>(
     let mut pending = 0usize;
     loop {
         match reader.next() {
-            Ok(Some((id, value))) => {
+            Ok(Some(Record { id, value })) => {
                 let rid = ResourceId::from(*id);
                 StateVersion::put(&mut wb, version, &rid, value);
                 StatePtrLatest::put(&mut wb, &rid, version);
@@ -167,9 +163,7 @@ pub fn restore_into_store<R: Read, H: Hasher, F: SnapshotFormat>(
 /// (`block_prove_to`, this header's own block) is a reachable selected-chain block reported from
 /// the pruning point, and a covenant settlement transaction committing `new_state` is among
 /// `containing_block`'s accepted transactions. Trust-minimized: a snapshot file that only
-/// self-verifies (root rebuild in [`restore_into_store`]) but was never actually confirmed by a
-/// settlement on this L1 fails here. Mirrors the bridge's own decode path
-/// (`l1/bridge/src/worker.rs`).
+/// self-verifies but was never actually confirmed by a settlement on this L1 fails here.
 pub async fn validate_against_l1<R: RpcApi>(
     client: &R,
     header: &SnapshotHeader,

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -9,7 +9,9 @@
 
 use std::{io::Read, path::Path};
 
-use kaspa_rpc_core::{RpcDataVerbosityLevel::Full, api::rpc::RpcApi};
+use kaspa_rpc_core::{
+    GetVirtualChainFromBlockV2Response, RpcDataVerbosityLevel::Full, api::rpc::RpcApi,
+};
 use vprogs_core_hashing::{Hasher, Sha256};
 use vprogs_core_smt::StreamingBuilder;
 use vprogs_core_types::{Checkpoint, ResourceId};
@@ -54,9 +56,13 @@ pub enum RestoreError {
     /// The local L1 node's RPC failed or otherwise could not be used to confirm the snapshot.
     #[error("L1 validation failed: {0}")]
     L1(String),
-    /// The local L1's reachable selected chain does not confirm the snapshot's settlement.
-    #[error("settlement not confirmed on the local L1's reachable chain")]
-    NotOnChain,
+    /// The snapshot's resume point is pruned, unknown, or on a chain this node has not selected.
+    #[error("snapshot resume point is not an unpruned selected-chain block on this node")]
+    ResumePointNotOnChain,
+    /// The resume point checks out, but the containing block carries no covenant settlement
+    /// committing this snapshot's root.
+    #[error("containing block accepted no covenant settlement committing this snapshot's root")]
+    SettlementNotAccepted,
     /// I/O failure while reading the snapshot file or writing the store.
     #[error("restore io error: {0}")]
     Io(#[from] std::io::Error),
@@ -160,10 +166,10 @@ pub fn restore_into_store<R: Read, H: Hasher, F: SnapshotFormat>(
 }
 
 /// Confirms `header`'s pinned settlement against the local L1 node: the resume point
-/// (`block_prove_to`, this header's own block) is a reachable selected-chain block reported from
-/// the pruning point, and a covenant settlement transaction committing `new_state` is among
-/// `containing_block`'s accepted transactions. Trust-minimized: a snapshot file that only
-/// self-verifies but was never actually confirmed by a settlement on this L1 fails here.
+/// (`block_prove_to`, this header's own block) is an unpruned selected-chain block, and a covenant
+/// settlement transaction committing `new_state` is among `containing_block`'s accepted
+/// transactions. Trust-minimized: a snapshot file that only self-verifies but was never actually
+/// confirmed by a settlement on this L1 fails here.
 pub async fn validate_against_l1<R: RpcApi>(
     client: &R,
     header: &SnapshotHeader,
@@ -184,44 +190,52 @@ pub async fn validate_against_l1<R: RpcApi>(
         )));
     }
 
-    // Chain from the pruning point: membership + reachability + at-or-after pruning in one call.
-    // Full verbosity so the response also carries accepted transactions per block.
-    let vc = client
-        .get_virtual_chain_from_block_v2(dag.pruning_point_hash, Some(Full), None)
-        .await
-        .map_err(|e| RestoreError::L1(format!("get_virtual_chain_from_block_v2: {e}")))?;
-
-    // The resume point (block_prove_to, this header's own block) must be a reachable chain block.
+    // Anchored on the resume point, not the pruning point: the node answers only for a block it
+    // still holds and reports an empty rollback only for one already on the selected chain, so a
+    // single response settles both, without walking the history a snapshot exists to skip.
     let resume_point = header.chain_block_metadata.hash;
-    if !vc.added_chain_block_hashes.contains(&resume_point) {
-        return Err(RestoreError::NotOnChain);
+    let mut page = chain_page(client, resume_point).await?;
+    if !page.removed_chain_block_hashes.is_empty() {
+        return Err(RestoreError::ResumePointNotOnChain);
     }
 
-    // Confirm a covenant settlement committing exactly this root, accepted in containing_block.
-    let mut confirmed = false;
-    for cb in vc.chain_block_accepted_transactions.iter() {
-        let bh = match cb.chain_block_header.hash {
-            Some(h) if h == s.containing_block => h,
-            _ => continue,
-        };
-        for tx in cb.accepted_transactions.iter() {
-            let l1tx = match L1Transaction::try_from(tx.clone()) {
-                Ok(tx) => tx,
-                Err(_) => continue,
-            };
-            if let Some(info) = l1tx.settlement_info(header.covenant_id, bh, s.daa_score.get()) {
-                if info.new_state == s.new_state && info.tx_id == s.tx_id {
-                    confirmed = true;
-                    break;
-                }
-            }
+    // Walk forward to the block the settlement transaction landed in. The node caps each response
+    // at its own batch size, so that block routinely sits past the first page and a single call
+    // cannot decide the question.
+    loop {
+        if let Some(cb) = page
+            .chain_block_accepted_transactions
+            .iter()
+            .find(|cb| cb.chain_block_header.hash == Some(s.containing_block))
+        {
+            let confirmed = cb.accepted_transactions.iter().any(|tx| {
+                L1Transaction::try_from(tx.clone()).is_ok_and(|l1tx| {
+                    l1tx.settlement_info(header.covenant_id, s.containing_block, s.daa_score.get())
+                        .is_some_and(|info| info.new_state == s.new_state && info.tx_id == s.tx_id)
+                })
+            });
+            return if confirmed { Ok(()) } else { Err(RestoreError::SettlementNotAccepted) };
         }
-        break;
+
+        // An empty page means the walk reached virtual without ever seeing the containing block.
+        let Some(cursor) = page.added_chain_block_hashes.last().copied() else {
+            return Err(RestoreError::SettlementNotAccepted);
+        };
+        page = chain_page(client, cursor).await?;
     }
-    if !confirmed {
-        return Err(RestoreError::NotOnChain);
-    }
-    Ok(())
+}
+
+/// One page of the selected chain after `start`, carrying each chain block's accepted transactions.
+async fn chain_page<R: RpcApi>(
+    client: &R,
+    start: Hash,
+) -> Result<GetVirtualChainFromBlockV2Response, RestoreError> {
+    // Full verbosity is load-bearing: below it the node returns no acceptance entries and
+    // truncates the chain-block list to match, so a cheaper level pages through an empty list.
+    client
+        .get_virtual_chain_from_block_v2(start, Some(Full), None)
+        .await
+        .map_err(|e| RestoreError::L1(format!("get_virtual_chain_from_block_v2: {e}")))
 }
 
 /// Outcome of a successful [`restore_snapshot`] call.

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -1,0 +1,329 @@
+//! Restore routine: seed a fresh RocksDB store + identity file from a snapshot file, but only
+//! after confirming (both internally and against the local L1 node) that the snapshot's pinned
+//! settlement is genuine.
+//!
+//! [`restore_into_store`] never buffers the whole snapshot: it streams each record straight into
+//! `data` + `latest_ptr`, committing in bounded chunks, while accumulating only the compact SMT
+//! commitments. The tree is rebuilt once at EOF and checked against the pinned settlement root
+//! before anything is written that would make the store look resumable; any failure after the
+//! store has been opened drops the freshly written column families, since the fresh data dir is
+//! exclusively ours at that point.
+
+use std::{io::Read, path::Path};
+
+use vprogs_core_hashing::Hasher;
+use vprogs_core_smt::{Commitment, Tree};
+use vprogs_core_types::Checkpoint;
+use vprogs_l1_types::SettlementInfo;
+use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
+use vprogs_state_metadata::StateMetadata;
+use vprogs_state_ptr_latest::StatePtrLatest;
+use vprogs_state_snapshot::SnapshotReader;
+use vprogs_state_version::StateVersion;
+use vprogs_storage_rocksdb_store::{DefaultConfig, RocksDbStore};
+use vprogs_storage_types::Store;
+
+use crate::{persistence::PersistedState, snapshot::header::SnapshotHeader};
+
+/// Records committed per write-batch while streaming a snapshot into the store. Bounds memory
+/// while still amortizing RocksDB write-batch overhead over many records.
+const CHUNK_SIZE: usize = 1000;
+
+/// Failure modes across the restore path: streaming a snapshot into a store, confirming it
+/// against the local L1, and the CLI orchestrator.
+#[derive(Debug)]
+pub enum RestoreError {
+    /// `data_dir` already holds a store or identity file; restore refuses to clobber it.
+    DataDirNotEmpty,
+    /// The snapshot file itself is malformed (bad magic/version/digest/framing) or internally
+    /// inconsistent (header doesn't match its own settlement).
+    BadSnapshot(String),
+    /// The header carries no settlement to restore from.
+    NoSettlement,
+    /// The SMT rebuilt from the snapshot's records does not match the pinned settlement root.
+    RootMismatch { rebuilt: [u8; 32], settlement: [u8; 32] },
+    /// The local L1 node's RPC failed or otherwise could not be used to confirm the snapshot.
+    L1(String),
+    /// The local L1's reachable selected chain does not confirm the snapshot's settlement.
+    NotOnChain,
+    /// I/O failure while reading the snapshot file or writing the store.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for RestoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RestoreError::DataDirNotEmpty => {
+                write!(f, "data dir already holds a store or identity file")
+            }
+            RestoreError::BadSnapshot(msg) => write!(f, "malformed snapshot: {msg}"),
+            RestoreError::NoSettlement => {
+                write!(f, "snapshot header carries no settlement to restore from")
+            }
+            RestoreError::RootMismatch { rebuilt, settlement } => write!(
+                f,
+                "rebuilt state root {} does not match settlement root {}",
+                faster_hex::hex_string(rebuilt),
+                faster_hex::hex_string(settlement)
+            ),
+            RestoreError::L1(msg) => write!(f, "L1 validation failed: {msg}"),
+            RestoreError::NotOnChain => {
+                write!(f, "settlement not confirmed on the local L1's reachable chain")
+            }
+            RestoreError::Io(e) => write!(f, "restore io error: {e}"),
+        }
+    }
+}
+impl std::error::Error for RestoreError {}
+impl From<std::io::Error> for RestoreError {
+    fn from(e: std::io::Error) -> Self {
+        RestoreError::Io(e)
+    }
+}
+
+/// Drops `store` and deletes the just-written `db_path`. Called only on a failure path after
+/// [`RocksDbStore::open`] has created a fresh directory exclusively ours, so a failed restore
+/// never leaves a partially written (but not-yet-verified) store behind.
+fn discard_store(store: RocksDbStore<DefaultConfig>, db_path: &Path) {
+    drop(store);
+    let _ = std::fs::remove_dir_all(db_path);
+}
+
+/// Streams `reader`'s records into a fresh store at `data_dir`, verifies the rebuilt SMT root
+/// against `header`'s pinned settlement, and only then writes the cursor (batch metadata, `metas`,
+/// and identity) that makes the store look like a node already committed up to the settlement
+/// block. Caller MUST have validated the snapshot against L1 first (see `validate_against_l1`);
+/// this function only re-confirms the file's own internal consistency.
+pub fn restore_into_store<R: Read, H: Hasher>(
+    data_dir: &Path,
+    header: &SnapshotHeader,
+    mut reader: SnapshotReader<R, H>,
+) -> Result<(), RestoreError> {
+    let db_path = data_dir.join("db");
+    if db_path.exists() || PersistedState::exists(data_dir) {
+        return Err(RestoreError::DataDirNotEmpty);
+    }
+    let settlement: SettlementInfo = header.settlement().ok_or(RestoreError::NoSettlement)?;
+    let version = header.committed_index;
+
+    let store = RocksDbStore::<DefaultConfig>::open(&db_path);
+
+    // Stream every record straight into `data` + `latest_ptr`, committing in bounded chunks, while
+    // accumulating only the compact SMT commitments (never the whole record set).
+    let mut commitments: Vec<Commitment> = Vec::new();
+    let mut wb = store.write_batch();
+    let mut pending = 0usize;
+    loop {
+        let record = match reader.next() {
+            Ok(Some(r)) => r,
+            Ok(None) => break,
+            Err(e) => {
+                discard_store(store, &db_path);
+                return Err(RestoreError::BadSnapshot(e.to_string()));
+            }
+        };
+        if !record.value.is_empty() {
+            commitments.push(Commitment::new(record.resource_id, H::hash(&record.value)));
+        }
+        StateVersion::put(&mut wb, version, &record.resource_id, &record.value);
+        StatePtrLatest::put(&mut wb, &record.resource_id, version);
+        pending += 1;
+        if pending >= CHUNK_SIZE {
+            store.commit(wb);
+            wb = store.write_batch();
+            pending = 0;
+        }
+    }
+    store.commit(wb);
+
+    if let Err(e) = reader.finish() {
+        discard_store(store, &db_path);
+        return Err(RestoreError::BadSnapshot(e.to_string()));
+    }
+
+    // Rebuild the SMT from the accumulated commitments and verify it against the pinned
+    // settlement root before writing anything that would make the store look resumable.
+    let mut wb = store.write_batch();
+    let root = store.update(&mut wb, commitments, version);
+    if root != settlement.new_state {
+        discard_store(store, &db_path);
+        return Err(RestoreError::RootMismatch { rebuilt: root, settlement: settlement.new_state });
+    }
+    let checkpoint = Checkpoint::new(version, header.chain_block_metadata);
+    StoredBatchMetadata::set(&mut wb, version, checkpoint.metadata());
+    StateMetadata::set_last_committed(&mut wb, &checkpoint);
+    StateMetadata::set_root(&mut wb, &checkpoint); // root == last_committed: no backfill
+    store.commit(wb);
+
+    // Identity: the resume seed is `block_prove_to` (this header's own block), never the later
+    // block the settlement transaction landed in. Harmless either way since `committed_index > 0`
+    // makes the bridge skip seeding altogether; this just keeps the persisted seed meaningful.
+    PersistedState {
+        lane_id: Some(header.lane_id),
+        covenant_id: Some(header.covenant_id.to_string()),
+        bootstrap_txid: Some(header.bootstrap_txid.to_string()),
+        bootstrap_block_hash: Some(header.chain_block_metadata.hash.to_string()),
+    }
+    .save(data_dir);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use vprogs_core_hashing::Sha256;
+    use vprogs_core_smt::Tree;
+    use vprogs_core_types::{Checkpoint, ResourceId};
+    use vprogs_l1_types::{ChainBlockMetadata, Hash, SettlementInfo};
+    use vprogs_state_metadata::StateMetadata;
+    use vprogs_state_snapshot::{Record, compute_root_from_records, write_snapshot};
+    use vprogs_state_version::StateVersion;
+    use vprogs_storage_rocksdb_store::{DefaultConfig, RocksDbStore};
+
+    use super::*;
+    use crate::persistence::PersistedState;
+
+    fn rec(b: u8, v: &[u8]) -> Record {
+        Record { resource_id: ResourceId::from([b; 32]), value: v.to_vec() }
+    }
+
+    fn minimal_header() -> SnapshotHeader {
+        SnapshotHeader {
+            covenant_id: Hash::from_bytes([1u8; 32]),
+            lane_id: 1,
+            bootstrap_txid: Hash::from_bytes([2u8; 32]),
+            committed_index: 1,
+            chain_block_metadata: ChainBlockMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn restore_seeds_resumable_store() {
+        let records = vec![rec(1, b"alpha"), rec(2, b"beta")];
+
+        // Compute the settlement root the same way a node would.
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = RocksDbStore::<DefaultConfig>::open(tmp.path());
+        let new_state = compute_root_from_records(&tmp_store, &records);
+
+        let block_prove_to = Hash::from_bytes([11u8; 32]);
+        let settlement = SettlementInfo {
+            block_prove_to,
+            containing_block: Hash::from_bytes([33u8; 32]),
+            new_state,
+            ..SettlementInfo::default()
+        };
+        let meta = ChainBlockMetadata {
+            hash: block_prove_to,
+            last_settlement: Some(settlement),
+            ..ChainBlockMetadata::default()
+        };
+        let header = SnapshotHeader {
+            covenant_id: Hash::from_bytes([7u8; 32]),
+            lane_id: 9,
+            bootstrap_txid: Hash::from_bytes([8u8; 32]),
+            committed_index: 4242,
+            chain_block_metadata: meta,
+        };
+
+        let mut bytes = Vec::new();
+        write_snapshot::<_, Sha256>(
+            &mut bytes,
+            &header.encode(),
+            records.len() as u64,
+            records.clone(),
+        )
+        .unwrap();
+
+        let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+        let header = SnapshotHeader::decode(&header_bytes).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        restore_into_store(dir.path(), &header, reader).expect("restore should succeed");
+
+        // Re-open the seeded store and assert it looks committed-up-to-the-settlement.
+        let store = RocksDbStore::<DefaultConfig>::open(dir.path().join("db"));
+        let last: Checkpoint<ChainBlockMetadata> = StateMetadata::last_committed(&store);
+        let root_cp: Checkpoint<ChainBlockMetadata> = StateMetadata::root(&store);
+        assert_eq!(last.index(), 4242);
+        assert_eq!(last.index(), root_cp.index()); // no backfill
+        assert_eq!(last.metadata().hash, block_prove_to);
+        assert_eq!(store.root(4242), new_state);
+        // Resource values are readable at the restored version.
+        assert_eq!(
+            StateVersion::from_latest_data(&store, ResourceId::from([1u8; 32])).data(),
+            b"alpha"
+        );
+
+        // Identity file written with the resume point (block_prove_to) as the resume seed.
+        let id = PersistedState::load(dir.path());
+        assert_eq!(id.lane_id, Some(9));
+        assert_eq!(id.covenant_hash(), Some(Hash::from_bytes([7u8; 32])));
+        assert_eq!(id.bootstrap_block(), Some(block_prove_to));
+    }
+
+    #[test]
+    fn restore_refuses_existing_store() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("db")).unwrap();
+
+        let header = minimal_header();
+        let mut bytes = Vec::new();
+        write_snapshot::<_, Sha256>(&mut bytes, &header.encode(), 0, Vec::new()).unwrap();
+        let (_header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+
+        assert!(matches!(
+            restore_into_store(dir.path(), &header, reader),
+            Err(RestoreError::DataDirNotEmpty)
+        ));
+    }
+
+    #[test]
+    fn restore_rejects_forged_root() {
+        // The pinned settlement root is honest (computed from `honest_records`)...
+        let honest_records = vec![rec(1, b"alpha"), rec(2, b"beta")];
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = RocksDbStore::<DefaultConfig>::open(tmp.path());
+        let honest_root = compute_root_from_records(&tmp_store, &honest_records);
+
+        let block_prove_to = Hash::from_bytes([11u8; 32]);
+        let settlement = SettlementInfo {
+            block_prove_to,
+            containing_block: Hash::from_bytes([33u8; 32]),
+            new_state: honest_root,
+            ..SettlementInfo::default()
+        };
+        let meta = ChainBlockMetadata {
+            hash: block_prove_to,
+            last_settlement: Some(settlement),
+            ..ChainBlockMetadata::default()
+        };
+        let header = SnapshotHeader {
+            covenant_id: Hash::from_bytes([7u8; 32]),
+            lane_id: 9,
+            bootstrap_txid: Hash::from_bytes([8u8; 32]),
+            committed_index: 4242,
+            chain_block_metadata: meta,
+        };
+
+        // ...but the file's actual records (tampered) hash to a different root.
+        let forged_records = vec![rec(1, b"EVIL!"), rec(2, b"beta")];
+        let mut bytes = Vec::new();
+        write_snapshot::<_, Sha256>(
+            &mut bytes,
+            &header.encode(),
+            forged_records.len() as u64,
+            forged_records,
+        )
+        .unwrap();
+
+        let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+        let header = SnapshotHeader::decode(&header_bytes).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            restore_into_store(dir.path(), &header, reader).expect_err("root should mismatch");
+        assert!(matches!(err, RestoreError::RootMismatch { .. }));
+        assert!(!dir.path().join("db").exists(), "a failed restore must not leave a db dir behind");
+    }
+}

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -390,6 +390,73 @@ mod tests {
         assert_eq!(id.bootstrap_block(), Some(block_prove_to));
     }
 
+    // The restored store carries exactly one batch-metadata entry, so the canonical chain a node
+    // replays from it has the anchor as both its base and its tip. Every SMT node the snapshot
+    // wrote sits at that one version, and a batch above it only resolves them while the anchor
+    // reads canonical.
+    #[test]
+    fn restored_state_stays_canonical_as_the_chain_extends() {
+        let records = vec![rec(1, b"alpha"), rec(2, b"beta")];
+        let new_state = settlement_root(&records, 4242);
+
+        let block_prove_to = Hash::from_bytes([11u8; 32]);
+        let settlement = SettlementInfo {
+            block_prove_to,
+            containing_block: Hash::from_bytes([33u8; 32]),
+            new_state,
+            ..SettlementInfo::default()
+        };
+        // The source node threaded this block onto a parent the restored log does not carry.
+        let meta = ChainBlockMetadata {
+            hash: block_prove_to,
+            parent_id: 4241,
+            last_settlement: Some(settlement),
+            ..ChainBlockMetadata::default()
+        };
+        let header = SnapshotHeader {
+            covenant_id: Hash::from_bytes([7u8; 32]),
+            lane_id: 9,
+            bootstrap_txid: Hash::from_bytes([8u8; 32]),
+            committed_index: 4242,
+            chain_block_metadata: meta,
+        };
+
+        let bytes = write_test_snapshot(&header.encode(), &records);
+        let (header_bytes, reader) =
+            SnapshotReader::<_, Sha256, VpsnapFormat>::open(bytes.as_slice()).unwrap();
+        let header = SnapshotHeader::decode(&header_bytes).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        restore_into_store(dir.path(), &header, reader).expect("restore should succeed");
+
+        // Start-up replay: the ancestry walk stops at the anchor rather than at a live parent.
+        let store = RocksDbStore::<DefaultConfig>::open(dir.path().join("db"));
+        let mut chain = store.canonical_chain_manager::<ChainBlockMetadata>();
+        assert_eq!(chain.chain().tip(), 4242);
+        assert!(chain.chain().snapshot().is_canonical(4242));
+        assert_eq!(store.root(4242), new_state);
+
+        // The next chain block threads onto the anchor, the way the bridge threads onto its sink.
+        let next = ChainBlockMetadata {
+            hash: Hash::from_bytes([12u8; 32]),
+            parent_id: chain.chain().tip(),
+            ..ChainBlockMetadata::default()
+        };
+        assert_eq!(chain.append(next).id, 4243);
+        let mut wb = store.write_batch();
+        StoredBatchMetadata::set(&mut wb, 4243, &next);
+        store.commit(wb);
+
+        // Restart with both entries: the anchor is still canonical, so a read at the newer batch
+        // still resolves the nodes the snapshot wrote.
+        drop(chain);
+        let chain = store.canonical_chain_manager::<ChainBlockMetadata>();
+        let snapshot = chain.chain().snapshot();
+        assert!(snapshot.is_canonical(4242));
+        assert!(snapshot.is_canonical(4243));
+        assert_eq!(store.root(4243), new_state);
+    }
+
     #[test]
     fn restore_refuses_existing_store() {
         let dir = tempfile::tempdir().unwrap();

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -12,10 +12,10 @@
 use std::{io::Read, path::Path};
 
 use kaspa_rpc_core::{RpcDataVerbosityLevel::Full, api::rpc::RpcApi};
-use vprogs_core_hashing::Hasher;
+use vprogs_core_hashing::{Hasher, Sha256};
 use vprogs_core_smt::{Commitment, Tree};
 use vprogs_core_types::Checkpoint;
-use vprogs_l1_types::{L1Transaction, L1TransactionCovenantExt, SettlementInfo};
+use vprogs_l1_types::{Hash, L1Transaction, L1TransactionCovenantExt, NetworkId, SettlementInfo};
 use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_state_ptr_latest::StatePtrLatest;
@@ -234,6 +234,57 @@ pub async fn validate_against_l1<R: RpcApi>(
         return Err(RestoreError::NotOnChain);
     }
     Ok(())
+}
+
+/// Outcome of a successful [`restore_snapshot`] call.
+pub struct RestoreSummary {
+    /// Covenant id the snapshot was taken from.
+    pub covenant_id: Hash,
+    /// Batch index the restored store's cursor now sits at.
+    pub committed_index: u64,
+    /// Number of resource records the snapshot carried.
+    pub record_count: u64,
+    /// L1 block a subsequent `vprun` run resumes fetching on top of (`block_prove_to`).
+    pub resume_from: Hash,
+}
+
+/// Reads `snapshot`, confirms it against `wrpc_url`'s L1 node, and seeds a fresh `data_dir` store
+/// and identity file from it. On success, a subsequent `vprun` run against `data_dir` resumes
+/// fetching on top of the settlement block.
+pub async fn restore_snapshot(
+    data_dir: &Path,
+    snapshot: &Path,
+    wrpc_url: &str,
+    network: NetworkId,
+) -> Result<RestoreSummary, RestoreError> {
+    let file = std::fs::File::open(snapshot)?;
+    let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(std::io::BufReader::new(file))
+        .map_err(|e| RestoreError::BadSnapshot(e.to_string()))?;
+    let header = SnapshotHeader::decode(&header_bytes)
+        .map_err(|e| RestoreError::BadSnapshot(e.to_string()))?;
+    let settlement = header.settlement().ok_or(RestoreError::NoSettlement)?;
+
+    // Header self-consistency: the header's own block IS block_prove_to (the resume point), never
+    // the later block the settlement transaction landed in (`settlement.containing_block`).
+    if header.chain_block_metadata.hash != settlement.block_prove_to {
+        return Err(RestoreError::BadSnapshot(
+            "header block hash does not match settlement.block_prove_to".into(),
+        ));
+    }
+    let record_count = reader.record_count();
+
+    // Independent L1 confirmation, then the streaming store population (which re-verifies the
+    // root internally as it writes).
+    let client = crate::wrpc::connect_wrpc(wrpc_url, network).await;
+    validate_against_l1(&client, &header).await?;
+    restore_into_store(data_dir, &header, reader)?;
+
+    Ok(RestoreSummary {
+        covenant_id: header.covenant_id,
+        committed_index: header.committed_index,
+        record_count,
+        resume_from: settlement.block_prove_to,
+    })
 }
 
 #[cfg(test)]

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -11,10 +11,11 @@
 
 use std::{io::Read, path::Path};
 
+use kaspa_rpc_core::{RpcDataVerbosityLevel::Full, api::rpc::RpcApi};
 use vprogs_core_hashing::Hasher;
 use vprogs_core_smt::{Commitment, Tree};
 use vprogs_core_types::Checkpoint;
-use vprogs_l1_types::SettlementInfo;
+use vprogs_l1_types::{L1Transaction, L1TransactionCovenantExt, SettlementInfo};
 use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_state_ptr_latest::StatePtrLatest;
@@ -29,8 +30,7 @@ use crate::{persistence::PersistedState, snapshot::header::SnapshotHeader};
 /// while still amortizing RocksDB write-batch overhead over many records.
 const CHUNK_SIZE: usize = 1000;
 
-/// Failure modes across the restore path: streaming a snapshot into a store, confirming it
-/// against the local L1, and the CLI orchestrator.
+/// Failure modes for [`restore_into_store`], [`validate_against_l1`], and the CLI orchestrator.
 #[derive(Debug)]
 pub enum RestoreError {
     /// `data_dir` already holds a store or identity file; restore refuses to clobber it.
@@ -166,6 +166,73 @@ pub fn restore_into_store<R: Read, H: Hasher>(
     }
     .save(data_dir);
 
+    Ok(())
+}
+
+/// Confirms `header`'s pinned settlement against the local L1 node: the resume point
+/// (`block_prove_to`, this header's own block) is a reachable selected-chain block reported from
+/// the pruning point, and a covenant settlement transaction committing `new_state` is among
+/// `containing_block`'s accepted transactions. Trust-minimized: a snapshot file that only
+/// self-verifies (root rebuild in [`restore_into_store`]) but was never actually confirmed by a
+/// settlement on this L1 fails here. Mirrors the bridge's own decode path
+/// (`l1/bridge/src/worker.rs`).
+pub async fn validate_against_l1<R: RpcApi>(
+    client: &R,
+    header: &SnapshotHeader,
+) -> Result<(), RestoreError> {
+    let s = header.settlement().ok_or(RestoreError::NoSettlement)?;
+
+    let dag = client
+        .get_block_dag_info()
+        .await
+        .map_err(|e| RestoreError::L1(format!("get_block_dag_info: {e}")))?;
+
+    // The settlement must not claim a DAA score ahead of the node's own virtual DAA.
+    if s.daa_score.get() > dag.virtual_daa_score {
+        return Err(RestoreError::L1(format!(
+            "settlement daa {} is ahead of virtual daa {}",
+            s.daa_score.get(),
+            dag.virtual_daa_score
+        )));
+    }
+
+    // Chain from the pruning point: membership + reachability + at-or-after pruning in one call.
+    // Full verbosity so the response also carries accepted transactions per block.
+    let vc = client
+        .get_virtual_chain_from_block_v2(dag.pruning_point_hash, Some(Full), None)
+        .await
+        .map_err(|e| RestoreError::L1(format!("get_virtual_chain_from_block_v2: {e}")))?;
+
+    // The resume point (block_prove_to, this header's own block) must be a reachable chain block.
+    let resume_point = header.chain_block_metadata.hash;
+    if !vc.added_chain_block_hashes.contains(&resume_point) {
+        return Err(RestoreError::NotOnChain);
+    }
+
+    // Confirm a covenant settlement committing exactly this root, accepted in containing_block.
+    let mut confirmed = false;
+    for cb in vc.chain_block_accepted_transactions.iter() {
+        let bh = match cb.chain_block_header.hash {
+            Some(h) if h == s.containing_block => h,
+            _ => continue,
+        };
+        for tx in cb.accepted_transactions.iter() {
+            let l1tx = match L1Transaction::try_from(tx.clone()) {
+                Ok(tx) => tx,
+                Err(_) => continue,
+            };
+            if let Some(info) = l1tx.settlement_info(header.covenant_id, bh, s.daa_score.get()) {
+                if info.new_state == s.new_state && info.tx_id == s.tx_id {
+                    confirmed = true;
+                    break;
+                }
+            }
+        }
+        break;
+    }
+    if !confirmed {
+        return Err(RestoreError::NotOnChain);
+    }
     Ok(())
 }
 

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -307,18 +307,14 @@ mod tests {
 
     /// Writes `records` (already in ascending id order) as a well-formed `VpsnapFormat` snapshot.
     fn write_test_snapshot(header: &[u8], records: &[([u8; 32], Vec<u8>)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut writer = SnapshotWriter::<_, Sha256, VpsnapFormat>::open(
-            &mut bytes,
-            header,
-            records.len() as u64,
-        )
-        .unwrap();
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        let mut writer =
+            SnapshotWriter::<_, Sha256, VpsnapFormat>::open(&mut bytes, header).unwrap();
         for (id, value) in records {
             writer.write_record(id, value).unwrap();
         }
         writer.finish().unwrap();
-        bytes
+        bytes.into_inner()
     }
 
     /// Computes the state root `records` would settle to, the same way a node does: a direct

--- a/runner/src/snapshot/restore.rs
+++ b/runner/src/snapshot/restore.rs
@@ -3,82 +3,67 @@
 //! settlement is genuine.
 //!
 //! [`restore_into_store`] never buffers the whole snapshot: it streams each record straight into
-//! `data` + `latest_ptr`, committing in bounded chunks, while accumulating only the compact SMT
-//! commitments. The tree is rebuilt once at EOF and checked against the pinned settlement root
-//! before anything is written that would make the store look resumable; any failure after the
-//! store has been opened drops the freshly written column families, since the fresh data dir is
-//! exclusively ours at that point.
+//! `data` + `latest_ptr` AND feeds it to a [`StreamingBuilder`] in the same pass, committing in
+//! bounded chunks. The builder retains only a bounded spine of not-yet-finalized SMT subtrees (see
+//! `vprogs_core_smt::builder`), so its writes land in the very same write-batch as the record's
+//! `data`/`latest_ptr` writes with no separate accumulation step. The root is sealed and checked
+//! against the pinned settlement root at EOF, in the final write-batch, before anything is written
+//! that would make the store look resumable; any failure after the store has been opened drops the
+//! freshly written column families, since the fresh data dir is exclusively ours at that point.
 
 use std::{io::Read, path::Path};
 
 use kaspa_rpc_core::{RpcDataVerbosityLevel::Full, api::rpc::RpcApi};
 use vprogs_core_hashing::{Hasher, Sha256};
-use vprogs_core_smt::{Commitment, Tree};
-use vprogs_core_types::Checkpoint;
+use vprogs_core_smt::StreamingBuilder;
+use vprogs_core_types::{Checkpoint, ResourceId};
 use vprogs_l1_types::{Hash, L1Transaction, L1TransactionCovenantExt, NetworkId, SettlementInfo};
 use vprogs_state_batch_metadata::BatchMetadata as StoredBatchMetadata;
 use vprogs_state_metadata::StateMetadata;
 use vprogs_state_ptr_latest::StatePtrLatest;
-use vprogs_state_snapshot::SnapshotReader;
+use vprogs_state_snapshot::{SnapshotFormat, SnapshotReader};
 use vprogs_state_version::StateVersion;
 use vprogs_storage_rocksdb_store::{DefaultConfig, RocksDbStore};
 use vprogs_storage_types::Store;
 
-use crate::{persistence::PersistedState, snapshot::header::SnapshotHeader};
+use crate::{
+    persistence::PersistedState,
+    snapshot::{VpsnapFormat, header::SnapshotHeader},
+};
 
 /// Records committed per write-batch while streaming a snapshot into the store. Bounds memory
 /// while still amortizing RocksDB write-batch overhead over many records.
 const CHUNK_SIZE: usize = 1000;
 
 /// Failure modes for [`restore_into_store`], [`validate_against_l1`], and the CLI orchestrator.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RestoreError {
     /// `data_dir` already holds a store or identity file; restore refuses to clobber it.
+    #[error("data dir already holds a store or identity file")]
     DataDirNotEmpty,
     /// The snapshot file itself is malformed (bad magic/version/digest/framing) or internally
     /// inconsistent (header doesn't match its own settlement).
+    #[error("malformed snapshot: {0}")]
     BadSnapshot(String),
     /// The header carries no settlement to restore from.
+    #[error("snapshot header carries no settlement to restore from")]
     NoSettlement,
     /// The SMT rebuilt from the snapshot's records does not match the pinned settlement root.
+    #[error(
+        "rebuilt state root {} does not match settlement root {}",
+        faster_hex::hex_string(.rebuilt),
+        faster_hex::hex_string(.settlement)
+    )]
     RootMismatch { rebuilt: [u8; 32], settlement: [u8; 32] },
     /// The local L1 node's RPC failed or otherwise could not be used to confirm the snapshot.
+    #[error("L1 validation failed: {0}")]
     L1(String),
     /// The local L1's reachable selected chain does not confirm the snapshot's settlement.
+    #[error("settlement not confirmed on the local L1's reachable chain")]
     NotOnChain,
     /// I/O failure while reading the snapshot file or writing the store.
-    Io(std::io::Error),
-}
-
-impl std::fmt::Display for RestoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RestoreError::DataDirNotEmpty => {
-                write!(f, "data dir already holds a store or identity file")
-            }
-            RestoreError::BadSnapshot(msg) => write!(f, "malformed snapshot: {msg}"),
-            RestoreError::NoSettlement => {
-                write!(f, "snapshot header carries no settlement to restore from")
-            }
-            RestoreError::RootMismatch { rebuilt, settlement } => write!(
-                f,
-                "rebuilt state root {} does not match settlement root {}",
-                faster_hex::hex_string(rebuilt),
-                faster_hex::hex_string(settlement)
-            ),
-            RestoreError::L1(msg) => write!(f, "L1 validation failed: {msg}"),
-            RestoreError::NotOnChain => {
-                write!(f, "settlement not confirmed on the local L1's reachable chain")
-            }
-            RestoreError::Io(e) => write!(f, "restore io error: {e}"),
-        }
-    }
-}
-impl std::error::Error for RestoreError {}
-impl From<std::io::Error> for RestoreError {
-    fn from(e: std::io::Error) -> Self {
-        RestoreError::Io(e)
-    }
+    #[error("restore io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Drops `store` and deletes the just-written `db_path`. Called only on a failure path after
@@ -94,10 +79,13 @@ fn discard_store(store: RocksDbStore<DefaultConfig>, db_path: &Path) {
 /// and identity) that makes the store look like a node already committed up to the settlement
 /// block. Caller MUST have validated the snapshot against L1 first (see `validate_against_l1`);
 /// this function only re-confirms the file's own internal consistency.
-pub fn restore_into_store<R: Read, H: Hasher>(
+///
+/// Generic over the framing identity `F`: a caller pins a concrete [`SnapshotFormat`] (e.g.
+/// `VpsnapFormat`) when it builds the `SnapshotReader` passed in here.
+pub fn restore_into_store<R: Read, H: Hasher, F: SnapshotFormat>(
     data_dir: &Path,
     header: &SnapshotHeader,
-    mut reader: SnapshotReader<R, H>,
+    mut reader: SnapshotReader<R, H, F>,
 ) -> Result<(), RestoreError> {
     let db_path = data_dir.join("db");
     if db_path.exists() || PersistedState::exists(data_dir) {
@@ -108,43 +96,49 @@ pub fn restore_into_store<R: Read, H: Hasher>(
 
     let store = RocksDbStore::<DefaultConfig>::open(&db_path);
 
-    // Stream every record straight into `data` + `latest_ptr`, committing in bounded chunks, while
-    // accumulating only the compact SMT commitments (never the whole record set).
-    let mut commitments: Vec<Commitment> = Vec::new();
+    // Every record streams straight into `data` + `latest_ptr` and is fed to the SMT builder, all
+    // in the same write-batch, committed in bounded chunks. Record order is not checked here: a
+    // snapshot that reorders or duplicates records (the header pins the settlement root, not the
+    // ordering) rebuilds to a different root, which the `root == settlement.new_state` check below
+    // rejects, so the record order is verified transitively.
+    let mut builder = StreamingBuilder::<H>::new(version);
     let mut wb = store.write_batch();
     let mut pending = 0usize;
     loop {
-        let record = match reader.next() {
-            Ok(Some(r)) => r,
+        match reader.next() {
+            Ok(Some((id, value))) => {
+                let rid = ResourceId::from(*id);
+                StateVersion::put(&mut wb, version, &rid, value);
+                StatePtrLatest::put(&mut wb, &rid, version);
+                // Empty value = resource absent from the tree (matches save's emit + the SMT's
+                // empty=absent contract); only non-empty values are live leaves.
+                if !value.is_empty() {
+                    builder.feed(&mut wb, rid, H::hash(value));
+                }
+
+                pending += 1;
+                if pending >= CHUNK_SIZE {
+                    store.commit(wb);
+                    wb = store.write_batch();
+                    pending = 0;
+                }
+            }
             Ok(None) => break,
             Err(e) => {
                 discard_store(store, &db_path);
                 return Err(RestoreError::BadSnapshot(e.to_string()));
             }
-        };
-        if !record.value.is_empty() {
-            commitments.push(Commitment::new(record.resource_id, H::hash(&record.value)));
-        }
-        StateVersion::put(&mut wb, version, &record.resource_id, &record.value);
-        StatePtrLatest::put(&mut wb, &record.resource_id, version);
-        pending += 1;
-        if pending >= CHUNK_SIZE {
-            store.commit(wb);
-            wb = store.write_batch();
-            pending = 0;
         }
     }
-    store.commit(wb);
 
     if let Err(e) = reader.finish() {
         discard_store(store, &db_path);
         return Err(RestoreError::BadSnapshot(e.to_string()));
     }
 
-    // Rebuild the SMT from the accumulated commitments and verify it against the pinned
-    // settlement root before writing anything that would make the store look resumable.
-    let mut wb = store.write_batch();
-    let root = store.update(&mut wb, commitments, version);
+    // Seal the tree into the final (possibly partial) batch and verify the root BEFORE writing the
+    // cursor that would make the store look resumable.
+    let root = builder.finish(&mut wb);
     if root != settlement.new_state {
         discard_store(store, &db_path);
         return Err(RestoreError::RootMismatch { rebuilt: root, settlement: settlement.new_state });
@@ -258,8 +252,9 @@ pub async fn restore_snapshot(
     network: NetworkId,
 ) -> Result<RestoreSummary, RestoreError> {
     let file = std::fs::File::open(snapshot)?;
-    let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(std::io::BufReader::new(file))
-        .map_err(|e| RestoreError::BadSnapshot(e.to_string()))?;
+    let (header_bytes, reader) =
+        SnapshotReader::<_, Sha256, VpsnapFormat>::open(std::io::BufReader::new(file))
+            .map_err(|e| RestoreError::BadSnapshot(e.to_string()))?;
     let header = SnapshotHeader::decode(&header_bytes)
         .map_err(|e| RestoreError::BadSnapshot(e.to_string()))?;
     let settlement = header.settlement().ok_or(RestoreError::NoSettlement)?;
@@ -290,19 +285,20 @@ pub async fn restore_snapshot(
 #[cfg(test)]
 mod tests {
     use vprogs_core_hashing::Sha256;
-    use vprogs_core_smt::Tree;
+    use vprogs_core_smt::{Commitment, Tree};
     use vprogs_core_types::{Checkpoint, ResourceId};
     use vprogs_l1_types::{ChainBlockMetadata, Hash, SettlementInfo};
     use vprogs_state_metadata::StateMetadata;
-    use vprogs_state_snapshot::{Record, compute_root_from_records, write_snapshot};
+    use vprogs_state_snapshot::SnapshotWriter;
     use vprogs_state_version::StateVersion;
     use vprogs_storage_rocksdb_store::{DefaultConfig, RocksDbStore};
 
     use super::*;
     use crate::persistence::PersistedState;
 
-    fn rec(b: u8, v: &[u8]) -> Record {
-        Record { resource_id: ResourceId::from([b; 32]), value: v.to_vec() }
+    /// One `(id, value)` snapshot record, `id = [b; 32]`.
+    fn rec(b: u8, v: &[u8]) -> ([u8; 32], Vec<u8>) {
+        ([b; 32], v.to_vec())
     }
 
     fn minimal_header() -> SnapshotHeader {
@@ -315,14 +311,44 @@ mod tests {
         }
     }
 
+    /// Writes `records` (already in ascending id order) as a well-formed `VpsnapFormat` snapshot.
+    fn write_test_snapshot(header: &[u8], records: &[([u8; 32], Vec<u8>)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut writer = SnapshotWriter::<_, Sha256, VpsnapFormat>::open(
+            &mut bytes,
+            header,
+            records.len() as u64,
+        )
+        .unwrap();
+        for (id, value) in records {
+            writer.write_record(id, value).unwrap();
+        }
+        writer.finish().unwrap();
+        bytes
+    }
+
+    /// Computes the state root `records` would settle to, the same way a node does: a direct
+    /// `store.update` of the non-empty commitments on a scratch store. Independent of
+    /// `restore_into_store`'s own `StreamingBuilder` path, so it is a genuine oracle for the
+    /// pinned settlement root in these tests.
+    fn settlement_root(records: &[([u8; 32], Vec<u8>)], version: u64) -> [u8; 32] {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RocksDbStore::<DefaultConfig>::open(tmp.path());
+        let commitments: Vec<Commitment> = records
+            .iter()
+            .filter(|(_, value)| !value.is_empty())
+            .map(|(id, value)| Commitment::new(ResourceId::from(*id), Sha256::hash(value)))
+            .collect();
+        let mut wb = store.write_batch();
+        let root = store.update(&mut wb, commitments, version);
+        store.commit(wb);
+        root
+    }
+
     #[test]
     fn restore_seeds_resumable_store() {
         let records = vec![rec(1, b"alpha"), rec(2, b"beta")];
-
-        // Compute the settlement root the same way a node would.
-        let tmp = tempfile::tempdir().unwrap();
-        let tmp_store = RocksDbStore::<DefaultConfig>::open(tmp.path());
-        let new_state = compute_root_from_records(&tmp_store, &records);
+        let new_state = settlement_root(&records, 4242);
 
         let block_prove_to = Hash::from_bytes([11u8; 32]);
         let settlement = SettlementInfo {
@@ -344,16 +370,10 @@ mod tests {
             chain_block_metadata: meta,
         };
 
-        let mut bytes = Vec::new();
-        write_snapshot::<_, Sha256>(
-            &mut bytes,
-            &header.encode(),
-            records.len() as u64,
-            records.clone(),
-        )
-        .unwrap();
+        let bytes = write_test_snapshot(&header.encode(), &records);
 
-        let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+        let (header_bytes, reader) =
+            SnapshotReader::<_, Sha256, VpsnapFormat>::open(bytes.as_slice()).unwrap();
         let header = SnapshotHeader::decode(&header_bytes).unwrap();
 
         let dir = tempfile::tempdir().unwrap();
@@ -386,9 +406,9 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("db")).unwrap();
 
         let header = minimal_header();
-        let mut bytes = Vec::new();
-        write_snapshot::<_, Sha256>(&mut bytes, &header.encode(), 0, Vec::new()).unwrap();
-        let (_header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+        let bytes = write_test_snapshot(&header.encode(), &[]);
+        let (_header_bytes, reader) =
+            SnapshotReader::<_, Sha256, VpsnapFormat>::open(bytes.as_slice()).unwrap();
 
         assert!(matches!(
             restore_into_store(dir.path(), &header, reader),
@@ -400,9 +420,7 @@ mod tests {
     fn restore_rejects_forged_root() {
         // The pinned settlement root is honest (computed from `honest_records`)...
         let honest_records = vec![rec(1, b"alpha"), rec(2, b"beta")];
-        let tmp = tempfile::tempdir().unwrap();
-        let tmp_store = RocksDbStore::<DefaultConfig>::open(tmp.path());
-        let honest_root = compute_root_from_records(&tmp_store, &honest_records);
+        let honest_root = settlement_root(&honest_records, 4242);
 
         let block_prove_to = Hash::from_bytes([11u8; 32]);
         let settlement = SettlementInfo {
@@ -426,16 +444,10 @@ mod tests {
 
         // ...but the file's actual records (tampered) hash to a different root.
         let forged_records = vec![rec(1, b"EVIL!"), rec(2, b"beta")];
-        let mut bytes = Vec::new();
-        write_snapshot::<_, Sha256>(
-            &mut bytes,
-            &header.encode(),
-            forged_records.len() as u64,
-            forged_records,
-        )
-        .unwrap();
+        let bytes = write_test_snapshot(&header.encode(), &forged_records);
 
-        let (header_bytes, reader) = SnapshotReader::<_, Sha256>::open(bytes.as_slice()).unwrap();
+        let (header_bytes, reader) =
+            SnapshotReader::<_, Sha256, VpsnapFormat>::open(bytes.as_slice()).unwrap();
         let header = SnapshotHeader::decode(&header_bytes).unwrap();
 
         let dir = tempfile::tempdir().unwrap();

--- a/runner/src/start.rs
+++ b/runner/src/start.rs
@@ -19,8 +19,9 @@ use secp256k1::Keypair;
 use tokio::{sync::watch, task::JoinHandle};
 use vprogs_core_atomics::AtomicAsyncLatch;
 use vprogs_core_smt::EMPTY_HASH;
-use vprogs_l1_types::SettlementInfo;
+use vprogs_l1_types::ChainBlockMetadata;
 use vprogs_l1_wallet::Wallet;
+use vprogs_state_metadata::StateMetadata;
 use vprogs_zk_backend_risc0_api::{Backend, ProofType};
 use vprogs_zk_backend_risc0_settler::{
     CovenantState, SettlementMode, SettlementWorkerConfig, bootstrap_dev_covenant,
@@ -421,8 +422,12 @@ where
     let tip_daa_obs = Arc::new(AtomicU64::new(0));
     // Live settlement channel: the bridge (writer) publishes the covenant's last on-chain
     // settlement here; the settler (reader) detects a competitor advancing past its in-memory
-    // tip.
-    let (settlement_tx, settlement_rx) = watch::channel(None::<SettlementInfo>);
+    // tip. Seeded from the store's own persisted settlement (`None` on a fresh bootstrap store) so
+    // a restored or resumed store's settler adopts the covenant tip without waiting on the bridge
+    // to re-observe a settlement that may reference a since-pruned deploy block.
+    let seed_settlement =
+        StateMetadata::last_committed::<ChainBlockMetadata, _>(&store).metadata().last_settlement;
+    let (settlement_tx, settlement_rx) = watch::channel(seed_settlement);
     // Seed the bridge with reorg headroom: pin the anchor only if it is already deep, else seed
     // seed_depth below the sink. The settler keeps the unmodified `start_from` (its own
     // resume/adopt semantics), so this only affects where the bridge roots its chain.


### PR DESCRIPTION
Third of four stacked branches for snapshot state-sync (fresh node past L1 pruning). Base: `snapshot-save`.

`vprun snapshot restore`: reads a snapshot file, confirms its pinned settlement against the local L1 node, then streams it into a fresh store and seeds the identity so a subsequent run resumes fetching on top of the settlement block.

- **Single-pass, bounded-memory restore**: each record streams into `data` + `latest_ptr` and, when non-empty, is fed to a `StreamingBuilder` (from snapshot-core), all in one write-batch committed every 1000 records. `builder.finish` seals the root into the final batch, which is checked against the pinned settlement root **before** the resumable cursor is written. Peak memory is bounded by the tree depth, not the record count. On any failure the freshly written db dir is dropped.
- **Order hardening**: the streaming builder requires strictly-ascending, unique ids and cannot sort mid-stream (unlike the old `store.update`), so a snapshot with a valid L1-confirmed header but reordered/duplicate records is rejected as a bad snapshot instead of being fed out of contract.
- **Trust model**: self-verify (rebuilt root == settlement root) AND independent L1 confirmation (resume point is a reachable selected-chain block at/after pruning; a covenant settlement committing that root is in the containing block's accepted txs).
- **Resume**: the restored store looks committed up to the settlement block; the settlement observer is seeded from persisted state so the settler adopts the covenant without referencing the pruned deploy.

Tests: streaming round-trip into a resumable store, forged-root rejection (no db left behind), out-of-order-records rejection, and the existing-dir guard.
