### PR TITLE
app-kit: host-only issuer crate for app drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9292,6 +9292,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "vprogs-zk-backend-risc0-app-kit"
+version = "0.1.0"
+dependencies = [
+ "kaspa-addresses",
+ "kaspa-consensus-core",
+ "kaspa-hashes",
+ "kaspa-rpc-core",
+ "kaspa-txscript",
+ "log",
+ "rand 0.8.5",
+ "secp256k1",
+ "tokio",
+ "vprogs-core-codec",
+ "vprogs-core-types",
+ "vprogs-l1-utils",
+ "vprogs-l1-wallet",
+ "vprogs-zk-abi",
+ "vprogs-zk-backend-risc0-api",
+ "vprogs-zk-backend-risc0-runtime-processor",
+]
+
+[[package]]
 name = "vprogs-zk-backend-risc0-covenant"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-members = [
   "zk/aggregate-prover",
   "zk/vm",
   "zk/backend/risc0/api",
+  "zk/backend/risc0/app-kit",
   "zk/backend/risc0/covenant",
   "zk/backend/risc0/settler",
   "zk/backend/risc0/test-suite",
@@ -42,6 +43,7 @@ members = [
   "transaction-runtime/*",
   "zk/abi",
   "zk/backend/risc0/api",
+  "zk/backend/risc0/app-kit",
   "zk/backend/risc0/covenant",
   "zk/backend/risc0/settler",
   "zk/backend/risc0/test-suite",
@@ -209,6 +211,7 @@ resolver = "3"
   vprogs-zk-abi                                   = { path = "zk/abi", default-features = false }
   vprogs-zk-aggregate-prover                      = { path = "zk/aggregate-prover" }
   vprogs-zk-backend-risc0-api                     = { path = "zk/backend/risc0/api", default-features = false }
+  vprogs-zk-backend-risc0-app-kit                 = { path = "zk/backend/risc0/app-kit" }
   vprogs-zk-backend-risc0-covenant                = { path = "zk/backend/risc0/covenant" }
   vprogs-zk-backend-risc0-runtime-processor       = { path = "zk/backend/risc0/runtime-processor", default-features = false }
   vprogs-zk-backend-risc0-settler                 = { path = "zk/backend/risc0/settler" }

--- a/zk/backend/risc0/app-kit/Cargo.toml
+++ b/zk/backend/risc0/app-kit/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+edition.workspace = true
+name              = "vprogs-zk-backend-risc0-app-kit"
+version.workspace = true
+
+[lib]
+name = "vprogs_zk_backend_risc0_app_kit"
+path = "src/lib.rs"
+
+[dependencies]
+kaspa-addresses                           = { workspace = true }
+kaspa-consensus-core                      = { workspace = true }
+kaspa-hashes                              = { workspace = true }
+kaspa-rpc-core                            = { workspace = true }
+kaspa-txscript                            = { workspace = true }
+log                                       = { workspace = true }
+rand                                      = { workspace = true }
+secp256k1                                 = { workspace = true }
+tokio                                     = { workspace = true, features = ["time"] }
+vprogs-core-codec                         = { workspace = true }
+vprogs-core-types                         = { workspace = true }
+vprogs-l1-utils                           = { workspace = true }
+vprogs-l1-wallet                          = { workspace = true }
+vprogs-zk-abi                             = { workspace = true, features = ["host"] }
+vprogs-zk-backend-risc0-api               = { workspace = true }
+vprogs-zk-backend-risc0-runtime-processor = { workspace = true }

--- a/zk/backend/risc0/app-kit/src/genesis.rs
+++ b/zk/backend/risc0/app-kit/src/genesis.rs
@@ -1,0 +1,79 @@
+//! Genesis key derivation and P2PK address helpers.
+//!
+//! Provides [`dev_genesis_keypair`] for the default dev genesis keypair (secp256k1 scalar 3)
+//! and [`p2pk_address`] for deriving network-prefixed P2PK addresses.
+
+use kaspa_addresses::{Address, Prefix, Version};
+use kaspa_consensus_core::config::params::Params;
+use secp256k1::{Keypair, SECP256K1, SecretKey};
+
+/// Creates the development genesis keypair (secp256k1 scalar `3`, BIP-340 test vector 0).
+///
+/// Panics if the generated x-only public key does not match `expected_pubkey` (such as the app's
+/// compiled `GENESIS_PUBKEY` constant), alerting operators immediately when running against
+/// custom-genesis guests without providing the matching private key.
+pub fn dev_genesis_keypair(expected_pubkey: &[u8; 32]) -> Keypair {
+    let mut secret = [0u8; 32];
+    secret[31] = 3;
+    let sk = SecretKey::from_slice(&secret).expect("scalar 3 is a valid secp256k1 secret key");
+    let keypair = Keypair::from_secret_key(SECP256K1, &sk);
+    let actual_pubkey = keypair.x_only_public_key().0.serialize();
+    assert_eq!(
+        &actual_pubkey, expected_pubkey,
+        "dev genesis keypair mismatch: expected {:?}, got {:?}",
+        expected_pubkey, actual_pubkey,
+    );
+    keypair
+}
+
+/// Derives the P2PK address for `pubkey` under the network prefix configured in `params`.
+pub fn p2pk_address(params: &Params, pubkey: &[u8; 32]) -> Address {
+    let prefix = Prefix::from(params.net.network_type());
+    Address::new(prefix, Version::PubKey, pubkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use kaspa_consensus_core::network::{NetworkId, NetworkType};
+    use vprogs_zk_backend_risc0_runtime_processor::genesis::GENESIS_SCHNORR_BYTES;
+
+    use super::*;
+
+    #[test]
+    fn test_dev_genesis_keypair_matches_bip340_vector_0() {
+        let keypair = dev_genesis_keypair(&GENESIS_SCHNORR_BYTES);
+        assert_eq!(keypair.x_only_public_key().0.serialize(), GENESIS_SCHNORR_BYTES);
+    }
+
+    #[test]
+    #[should_panic(expected = "dev genesis keypair mismatch")]
+    fn test_dev_genesis_keypair_mismatch_panics() {
+        let wrong_pubkey = [0x00u8; 32];
+        dev_genesis_keypair(&wrong_pubkey);
+    }
+
+    #[test]
+    fn test_p2pk_address_network_prefixes() {
+        let pubkey = [0x42u8; 32];
+
+        let mainnet_params = Params::from(NetworkId::new(NetworkType::Mainnet));
+        let addr_mainnet = p2pk_address(&mainnet_params, &pubkey);
+        assert_eq!(addr_mainnet.prefix, Prefix::Mainnet);
+        assert_eq!(&addr_mainnet.payload[..], &pubkey[..]);
+
+        let testnet_params = Params::from(NetworkId::with_suffix(NetworkType::Testnet, 10));
+        let addr_testnet = p2pk_address(&testnet_params, &pubkey);
+        assert_eq!(addr_testnet.prefix, Prefix::Testnet);
+        assert_eq!(&addr_testnet.payload[..], &pubkey[..]);
+
+        let simnet_params = Params::from(NetworkId::new(NetworkType::Simnet));
+        let addr_simnet = p2pk_address(&simnet_params, &pubkey);
+        assert_eq!(addr_simnet.prefix, Prefix::Simnet);
+        assert_eq!(&addr_simnet.payload[..], &pubkey[..]);
+
+        let devnet_params = Params::from(NetworkId::new(NetworkType::Devnet));
+        let addr_devnet = p2pk_address(&devnet_params, &pubkey);
+        assert_eq!(addr_devnet.prefix, Prefix::Devnet);
+        assert_eq!(&addr_devnet.payload[..], &pubkey[..]);
+    }
+}

--- a/zk/backend/risc0/app-kit/src/lane.rs
+++ b/zk/backend/risc0/app-kit/src/lane.rs
@@ -1,0 +1,285 @@
+//! Carrier transaction composition and submission helpers.
+//!
+//! Bridges [`LanePayload`] assembly with [`vprogs_l1_wallet::build::signed_carrier_transaction`]
+//! for single-UTXO funded carrier transactions (deposits and lane actions), and provides
+//! [`fund_and_submit`] with transient-rejection retry loops.
+
+use std::{cell::RefCell, time::Duration};
+
+use kaspa_addresses::Address;
+use kaspa_consensus_core::{
+    config::params::Params,
+    subnets::SubnetworkId,
+    tx::{Transaction, TransactionOutpoint, TransactionOutput, UtxoEntry},
+};
+use kaspa_hashes::Hash;
+use kaspa_rpc_core::api::rpc::RpcApi;
+use kaspa_txscript::standard::pay_to_script_hash_script;
+use secp256k1::Keypair;
+use vprogs_l1_wallet::{
+    Wallet,
+    build::{SignedCarrierTx, signed_carrier_transaction},
+};
+use vprogs_zk_backend_risc0_api::build_delegate_entry_script;
+
+use crate::payload::{LanePayload, SigRequest};
+
+/// Default maximum submit attempts for transient rejections.
+pub const DEFAULT_MAX_SUBMIT_ATTEMPTS: u32 = 8;
+/// Default back-off duration between retry attempts.
+pub const DEFAULT_SUBMIT_RETRY_DELAY: Duration = Duration::from_millis(2000);
+
+/// Common transaction arguments for building a signed carrier.
+pub struct CarrierTxArgs<'a> {
+    /// The funding outpoint to spend.
+    pub outpoint: TransactionOutpoint,
+    /// The funding outpoint's UTXO entry.
+    pub entry: UtxoEntry,
+    /// Keypair that signs and funds the input.
+    pub keypair: Keypair,
+    /// Address to which change (after extra outputs and fee) is paid.
+    pub change_address: &'a Address,
+    /// Subnetwork id the carrier transaction rides on.
+    pub subnetwork_id: SubnetworkId,
+    /// Transaction version (e.g. `TX_VERSION_TOCCATA`).
+    pub tx_version: u16,
+    /// Consensus parameters for fee and storage mass calculation.
+    pub params: &'a Params,
+    /// Extra outputs prepended before the change output (e.g. deposit outputs).
+    pub extra_outputs: Vec<TransactionOutput>,
+}
+
+/// Builds one covenant deposit output: `P2SH(delegate_entry_script(covenant_id))`.
+///
+/// This matches the script commit produced by the guest's `DepositPolicy::deposit_spk`.
+/// Deposit transactions place this as output 0; the Deposit action cites `output_idx = 0`.
+pub fn covenant_deposit_output(covenant_id: &[u8; 32], value: u64) -> TransactionOutput {
+    let spk = pay_to_script_hash_script(&build_delegate_entry_script(covenant_id));
+    TransactionOutput::new(value, spk)
+}
+
+/// Builds one signed lane-action carrier whose payload is finalized over the carrier's
+/// `rest_preimage`.
+///
+/// The transaction is fee-priced using a fixed-size probe, outputs are frozen, and the real
+/// payload is signed over the finalized `rest_preimage` before L1 input signing.
+pub fn signed_lane_action_tx(
+    args: CarrierTxArgs<'_>,
+    payload: &LanePayload,
+    sign: &mut dyn FnMut(SigRequest<'_>) -> [u8; 64],
+) -> Transaction {
+    let sign_cell = RefCell::new(sign);
+    signed_carrier_transaction(SignedCarrierTx {
+        outpoint: args.outpoint,
+        entry: args.entry,
+        keypair: args.keypair,
+        change_address: args.change_address,
+        subnetwork_id: args.subnetwork_id,
+        tx_version: args.tx_version,
+        params: args.params,
+        extra_outputs: args.extra_outputs,
+        finalize_payload: |rest: &[u8]| payload.finish(rest, &mut *sign_cell.borrow_mut()),
+    })
+}
+
+/// Builds one signed deposit carrier: extra outputs are placed first, followed by change.
+///
+/// The payload is signature-free, evaluated via [`LanePayload::finish_unsigned`].
+pub fn signed_deposit_tx(args: CarrierTxArgs<'_>, payload: &LanePayload) -> Transaction {
+    signed_carrier_transaction(SignedCarrierTx {
+        outpoint: args.outpoint,
+        entry: args.entry,
+        keypair: args.keypair,
+        change_address: args.change_address,
+        subnetwork_id: args.subnetwork_id,
+        tx_version: args.tx_version,
+        params: args.params,
+        extra_outputs: args.extra_outputs,
+        finalize_payload: |_: &[u8]| payload.finish_unsigned(),
+    })
+}
+
+/// Determines whether an RPC submit rejection is transient (mempool orphan or timeout).
+pub fn is_transient_submit_error(err: &impl std::fmt::Display) -> bool {
+    let msg = err.to_string();
+    msg.contains("orphan") || msg.contains("timed out") || msg.contains("timeout")
+}
+
+/// Fetches spendable UTXOs, builds a carrier via `build`, and submits with retry back-off.
+///
+/// Re-fetches spendable UTXOs on transient rejections to adapt to mined UTXOs, returning
+/// `Some(tx_id)` on acceptance or `None` if funding fails or retries are exhausted.
+pub async fn fund_and_submit<C: RpcApi + ?Sized>(
+    label: &str,
+    wallet: &Wallet<'_, C>,
+    build: impl Fn(Vec<(TransactionOutpoint, UtxoEntry)>) -> Option<Transaction>,
+    attempts: u32,
+    retry_delay: Duration,
+) -> Option<Hash> {
+    for attempt in 1..=attempts {
+        let candidates = match wallet.fetch_spendable_utxos().await {
+            Ok(utxos) => utxos,
+            Err(e) => {
+                log::warn!("{label}: spendable-utxo fetch failed: {e}");
+                return None;
+            }
+        };
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let tx = build(candidates)?;
+        match wallet.submit_transaction(&tx).await {
+            Ok(id) => return Some(id),
+            Err(e) if is_transient_submit_error(&e) && attempt < attempts => {
+                log::warn!("{label} rejected (attempt {attempt}/{attempts}, retrying): {e}");
+                tokio::time::sleep(retry_delay).await;
+            }
+            Err(e) => {
+                log::warn!("{label} not submitted: {e}");
+                return None;
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use kaspa_addresses::{Prefix, Version};
+    use kaspa_consensus_core::{
+        constants::TX_VERSION_TOCCATA,
+        hashing::tx::transaction_v1_rest_preimage,
+        network::{NetworkId, NetworkType},
+        subnets::SUBNETWORK_ID_NATIVE,
+    };
+    use kaspa_txscript::pay_to_address_script;
+    use secp256k1::{Message, SECP256K1, SecretKey};
+    use vprogs_core_types::{AccessMetadata, AccessType};
+    use vprogs_l1_wallet::build::min_fee;
+    use vprogs_zk_backend_risc0_runtime_processor::{
+        runtime::compute_sig_message, signer_trait::Signer, signer_variants::SchnorrSigPtrSigner,
+    };
+
+    use super::*;
+    use crate::signer::{Bip340Signer, SignerKind, SignerSpec, TailBlock};
+
+    #[test]
+    fn test_deposit_fee_clears_min_on_shrunk_change() {
+        let params = Params::from(NetworkId::with_suffix(NetworkType::Testnet, 10));
+        let mut secret = [0u8; 32];
+        secret[31] = 9;
+        let keypair = Keypair::from_secret_key(SECP256K1, &SecretKey::from_slice(&secret).unwrap());
+        let change_address = Address::new(
+            Prefix::Testnet,
+            Version::PubKey,
+            &keypair.x_only_public_key().0.serialize(),
+        );
+        let covenant_id = [7u8; 32];
+        let deposit_value = 100_000_000u64;
+        let funding = 150_000_000u64;
+
+        let entry = UtxoEntry::new(funding, pay_to_address_script(&change_address), 0, false, None);
+        let outpoint = TransactionOutpoint::new(Hash::from_bytes([1u8; 32]), 0);
+
+        let user_id = [0xaa; 32];
+        let config_id = [0xcc; 32];
+        let deposit_action = vec![0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let payload = LanePayload::new()
+            .access(AccessMetadata { resource_id: user_id.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: config_id.into(), access_type: AccessType::Read })
+            .action(deposit_action);
+
+        let deposit_output = covenant_deposit_output(&covenant_id, deposit_value);
+
+        let tx = signed_deposit_tx(
+            CarrierTxArgs {
+                outpoint,
+                entry: entry.clone(),
+                keypair,
+                change_address: &change_address,
+                subnetwork_id: SUBNETWORK_ID_NATIVE,
+                tx_version: TX_VERSION_TOCCATA,
+                params: &params,
+                extra_outputs: vec![deposit_output],
+            },
+            &payload,
+        );
+
+        assert_eq!(tx.outputs[0].value, deposit_value);
+        let change = tx.outputs[1].value;
+        let fee_paid = funding - deposit_value - change;
+        let required = min_fee(&params, &tx);
+        assert!(fee_paid >= required, "deposit underpaid: fee {fee_paid} < required {required}");
+    }
+
+    #[test]
+    fn test_signed_lane_action_tx_splices_valid_sig() {
+        let params = Params::from(NetworkId::with_suffix(NetworkType::Testnet, 10));
+        let mut secret = [0u8; 32];
+        secret[31] = 5;
+        let keypair = Keypair::from_secret_key(SECP256K1, &SecretKey::from_slice(&secret).unwrap());
+        let change_address = Address::new(
+            Prefix::Testnet,
+            Version::PubKey,
+            &keypair.x_only_public_key().0.serialize(),
+        );
+
+        let signer = Bip340Signer::new();
+        let funding = 50_000_000u64;
+        let entry = UtxoEntry::new(funding, pay_to_address_script(&change_address), 0, false, None);
+        let outpoint = TransactionOutpoint::new(Hash::from_bytes([2u8; 32]), 1);
+
+        let res0 = [0x11u8; 32];
+        let res1 = [0x22u8; 32];
+        let action = vec![0x03, 0x00, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let payload = LanePayload::new()
+            .access(AccessMetadata { resource_id: res0.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: res1.into(), access_type: AccessType::Write })
+            .action(action)
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            });
+
+        let tx = signed_lane_action_tx(
+            CarrierTxArgs {
+                outpoint,
+                entry: entry.clone(),
+                keypair,
+                change_address: &change_address,
+                subnetwork_id: SUBNETWORK_ID_NATIVE,
+                tx_version: TX_VERSION_TOCCATA,
+                params: &params,
+                extra_outputs: vec![],
+            },
+            &payload,
+            &mut |req| signer.sign_digest(req.digest),
+        );
+
+        // Verify the payload in the transaction is finalized with a signature committing to the tx
+        // rest_preimage
+        let presig = payload.presig();
+        assert_eq!(&tx.payload[..presig.len()], &presig[..]);
+
+        let rest = transaction_v1_rest_preimage(&tx);
+        let expected_digest = compute_sig_message(&rest, &presig);
+        let sig_bytes = &tx.payload[presig.len()..presig.len() + 64];
+
+        let msg = Message::from_digest(expected_digest);
+        let xonly = secp256k1::XOnlyPublicKey::from_slice(&signer.pubkey()).unwrap();
+        let sig = secp256k1::schnorr::Signature::from_slice(sig_bytes).unwrap();
+        assert!(SECP256K1.verify_schnorr(&sig, &msg, &xonly).is_ok());
+    }
+
+    #[test]
+    fn test_is_transient_submit_error() {
+        assert!(is_transient_submit_error(&"transaction is an orphan"));
+        assert!(is_transient_submit_error(&"request timed out"));
+        assert!(is_transient_submit_error(&"RPC timeout"));
+        assert!(!is_transient_submit_error(&"transaction rejected: invalid signature"));
+        assert!(!is_transient_submit_error(&"fee too low"));
+    }
+}

--- a/zk/backend/risc0/app-kit/src/lib.rs
+++ b/zk/backend/risc0/app-kit/src/lib.rs
@@ -1,9 +1,15 @@
 //! Host-side issuer kit over the runtime battery and the L1 wallet: lane-payload
 //! assembly, carrier composition, submit retries; the runner stays issuer-free.
 
+pub mod lane;
 pub mod payload;
 pub mod signer;
 
+pub use lane::{
+    CarrierTxArgs, DEFAULT_MAX_SUBMIT_ATTEMPTS, DEFAULT_SUBMIT_RETRY_DELAY,
+    covenant_deposit_output, fund_and_submit, is_transient_submit_error, signed_deposit_tx,
+    signed_lane_action_tx,
+};
 pub use payload::{LanePayload, SigRequest};
 pub use signer::{
     Bip340Signer, GenesisSchnorrSigPtrSigner, MultisigPrevTxV1WitnessSigner,

--- a/zk/backend/risc0/app-kit/src/lib.rs
+++ b/zk/backend/risc0/app-kit/src/lib.rs
@@ -1,10 +1,12 @@
 //! Host-side issuer kit over the runtime battery and the L1 wallet: lane-payload
 //! assembly, carrier composition, submit retries; the runner stays issuer-free.
 
+pub mod genesis;
 pub mod lane;
 pub mod payload;
 pub mod signer;
 
+pub use genesis::{dev_genesis_keypair, p2pk_address};
 pub use lane::{
     CarrierTxArgs, DEFAULT_MAX_SUBMIT_ATTEMPTS, DEFAULT_SUBMIT_RETRY_DELAY,
     covenant_deposit_output, fund_and_submit, is_transient_submit_error, signed_deposit_tx,

--- a/zk/backend/risc0/app-kit/src/lib.rs
+++ b/zk/backend/risc0/app-kit/src/lib.rs
@@ -1,0 +1,12 @@
+//! Host-side issuer kit over the runtime battery and the L1 wallet: lane-payload
+//! assembly, carrier composition, submit retries; the runner stays issuer-free.
+
+pub mod payload;
+pub mod signer;
+
+pub use payload::{LanePayload, SigRequest};
+pub use signer::{
+    Bip340Signer, GenesisSchnorrSigPtrSigner, MultisigPrevTxV1WitnessSigner,
+    MultisigSchnorrSigPtrSigner, PrevTxV1WitnessSigner, SchnorrSigPtrSigner, SignerKind,
+    SignerSpec, TailBlock,
+};

--- a/zk/backend/risc0/app-kit/src/payload.rs
+++ b/zk/backend/risc0/app-kit/src/payload.rs
@@ -1,0 +1,470 @@
+//! Assembly of runtime lane payloads across access metadata, signers, actions, and tail blocks.
+//!
+//! Implements the two-pass layout algorithm that probes the signers section with
+//! zero offsets to determine section lengths, calculates concrete tail offsets,
+//! and patches signer entries before producing the finalized payload bytes.
+
+use vprogs_core_types::AccessMetadata;
+use vprogs_l1_wallet::encode_activity_payload;
+use vprogs_zk_backend_risc0_runtime_processor::runtime::compute_sig_message;
+
+use crate::signer::{SignerKind, SignerSpec, TailBlock, encode_signer_entry};
+
+/// Host-side assembly of one lane payload over the runtime ix framing:
+/// `payload.bytes = access_meta || signers_section || actions_section || tail`.
+///
+/// The caller supplies sorted `access` (strictly ascending by resource id, the
+/// ABI-layer invariant), app-encoded `actions` (each already `tag || body`), and
+/// `signers` (non-strict ascending by `resource_idx`, the `decode_ix` invariant;
+/// within a resource, ascending by pubkey). The assembler computes every tail
+/// offset two-pass: a probe with zero offsets sizes the signers section, whose
+/// length is invariant to the offset values, then the real tail block offsets
+/// are patched in.
+#[derive(Clone, Debug, Default)]
+pub struct LanePayload {
+    /// Ordered resource access metadata declarations.
+    access: Vec<AccessMetadata>,
+    /// Encoded action bodies (`tag || body`).
+    actions: Vec<Vec<u8>>,
+    /// Signer specifications and their associated tail blocks.
+    signers: Vec<SignerSpec>,
+}
+
+/// What [`LanePayload::finish`] hands the signing closure: the signer's position in
+/// the signers list and the BIP-340 digest `compute_sig_message(rest, presig)`.
+pub struct SigRequest<'a> {
+    /// Zero-based position of the signer within the payload's signers list.
+    pub signer: usize,
+    /// The 32-byte BIP-340 signature message digest.
+    pub digest: &'a [u8; 32],
+}
+
+impl LanePayload {
+    /// Creates an empty lane payload builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends one access entry. Callers must add them in ascending resource-id order.
+    pub fn access(mut self, meta: AccessMetadata) -> Self {
+        self.access.push(meta);
+        self
+    }
+
+    /// Appends one app-encoded action body (`tag || body`), preserving order.
+    pub fn action(mut self, body: Vec<u8>) -> Self {
+        self.actions.push(body);
+        self
+    }
+
+    /// Appends one signer. Callers must add them ascending by `resource_idx`
+    /// (non-strict), and within a resource ascending by pubkey.
+    pub fn signer(mut self, spec: SignerSpec) -> Self {
+        self.signers.push(spec);
+        self
+    }
+
+    /// Returns the pre-signature prefix `access_meta || signers_section || actions_section`.
+    ///
+    /// This corresponds to `payload.bytes[..end_of_actions]`, the byte slice a Schnorr
+    /// signer commits to via [`compute_sig_message`].
+    pub fn presig(&self) -> Vec<u8> {
+        let access_meta = encode_activity_payload(&self.access, &[]);
+        let actions_section = encode_actions_section(&self.actions);
+
+        // Pass 1: probe signers section with zero offsets to measure its fixed size.
+        let mut probe_bytes = Vec::new();
+        probe_bytes.extend_from_slice(&(self.signers.len() as u32).to_le_bytes());
+        for spec in &self.signers {
+            let entry = encode_signer_entry(spec.resource_idx, &spec.kind, 0, (0, 0, 0));
+            probe_bytes.extend_from_slice(&entry);
+        }
+
+        let presig_len = access_meta.len() + probe_bytes.len() + actions_section.len();
+
+        // Pass 2: compute concrete tail offsets starting immediately after presig.
+        let mut current_tail_offset = presig_len;
+        let mut signers_section = Vec::with_capacity(probe_bytes.len());
+        signers_section.extend_from_slice(&(self.signers.len() as u32).to_le_bytes());
+
+        for spec in &self.signers {
+            let entry = match (&spec.kind, &spec.tail) {
+                (
+                    SignerKind::SigPtr { .. } | SignerKind::MultisigSigPtr { .. },
+                    TailBlock::Sig64,
+                ) => {
+                    let sig_offset = current_tail_offset as u32;
+                    current_tail_offset += 64;
+                    encode_signer_entry(spec.resource_idx, &spec.kind, sig_offset, (0, 0, 0))
+                }
+                (SignerKind::Witness { .. }, TailBlock::Witness { prev_rest_preimage, .. }) => {
+                    let rp_off = current_tail_offset as u32;
+                    let rp_len = prev_rest_preimage.len() as u32;
+                    current_tail_offset += prev_rest_preimage.len();
+                    let pd_off = current_tail_offset as u32;
+                    current_tail_offset += 32;
+                    encode_signer_entry(spec.resource_idx, &spec.kind, 0, (rp_off, rp_len, pd_off))
+                }
+                _ => panic!("mismatched SignerKind and TailBlock in SignerSpec"),
+            };
+            signers_section.extend_from_slice(&entry);
+        }
+
+        debug_assert_eq!(signers_section.len(), probe_bytes.len());
+
+        let mut presig = Vec::with_capacity(presig_len);
+        presig.extend_from_slice(&access_meta);
+        presig.extend_from_slice(&signers_section);
+        presig.extend_from_slice(&actions_section);
+        debug_assert_eq!(presig.len(), presig_len);
+
+        presig
+    }
+
+    /// Completes the payload: lays out the tail (one block per signer, in signer
+    /// order), patches each entry's offsets to its block, and fills `Sig64` blocks
+    /// by calling `sign` with `compute_sig_message(rest_preimage, presig)`.
+    ///
+    /// The resulting payload length is independent of `rest_preimage` contents.
+    pub fn finish(
+        &self,
+        rest_preimage: &[u8],
+        sign: &mut dyn FnMut(SigRequest<'_>) -> [u8; 64],
+    ) -> Vec<u8> {
+        let presig = self.presig();
+        let digest = compute_sig_message(rest_preimage, &presig);
+
+        let mut payload = presig;
+        for (idx, spec) in self.signers.iter().enumerate() {
+            match &spec.tail {
+                TailBlock::Sig64 => {
+                    let sig = sign(SigRequest { signer: idx, digest: &digest });
+                    payload.extend_from_slice(&sig);
+                }
+                TailBlock::Witness { prev_rest_preimage, prev_payload_digest } => {
+                    payload.extend_from_slice(prev_rest_preimage);
+                    payload.extend_from_slice(prev_payload_digest);
+                }
+            }
+        }
+        payload
+    }
+
+    /// Completes signature-free payloads (such as deposits or witness-only transactions).
+    ///
+    /// Panics if any signer requires a signature slot ([`TailBlock::Sig64`]).
+    pub fn finish_unsigned(&self) -> Vec<u8> {
+        let presig = self.presig();
+
+        let mut payload = presig;
+        for spec in &self.signers {
+            match &spec.tail {
+                TailBlock::Sig64 => {
+                    panic!(
+                        "finish_unsigned called on payload with Sig64 tail blocks; use finish instead"
+                    );
+                }
+                TailBlock::Witness { prev_rest_preimage, prev_payload_digest } => {
+                    payload.extend_from_slice(prev_rest_preimage);
+                    payload.extend_from_slice(prev_payload_digest);
+                }
+            }
+        }
+        payload
+    }
+}
+
+/// Encodes an actions section with little-endian count prefix followed by bodies.
+fn encode_actions_section(actions: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(actions.len() as u32).to_le_bytes());
+    for a in actions {
+        out.extend_from_slice(a);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use vprogs_core_types::AccessType;
+    use vprogs_zk_backend_risc0_runtime_processor::{
+        ix::decode_ix,
+        signer_trait::Signer,
+        signer_variants::{
+            GenesisSchnorrSigPtrSigner, MultisigSchnorrSigPtrSigner, PrevTxV1WitnessSigner,
+            SchnorrSigPtrSigner,
+        },
+    };
+
+    use super::*;
+    use crate::signer::Bip340Signer;
+
+    #[test]
+    fn test_single_schnorr_payload_parity() {
+        let signer = Bip340Signer::new();
+        let resource_id0 = [0x11u8; 32];
+        let resource_id1 = [0x22u8; 32];
+        let action_body =
+            vec![0x03, 0x00, 0x01, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let payload_builder = LanePayload::new()
+            .access(AccessMetadata {
+                resource_id: resource_id0.into(),
+                access_type: AccessType::Write,
+            })
+            .access(AccessMetadata {
+                resource_id: resource_id1.into(),
+                access_type: AccessType::Write,
+            })
+            .action(action_body.clone())
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            });
+
+        let rest_preimage = [0x55u8; 64];
+        let mut signed_sig = [0u8; 64];
+        let finalized = payload_builder.finish(&rest_preimage, &mut |req| {
+            assert_eq!(req.signer, 0);
+            signed_sig = signer.sign_digest(req.digest);
+            signed_sig
+        });
+
+        // Verify presig layout:
+        // access_meta: 4 bytes count + 2 * (32 bytes id + 1 byte access_type) = 70 bytes
+        // signers: 4 bytes count + (1 byte res_idx + 1 byte tag + 4 bytes sig_offset) = 10 bytes
+        // actions: 4 bytes count + 12 bytes body = 16 bytes
+        // presig_len = 70 + 10 + 16 = 96 bytes
+        let presig = payload_builder.presig();
+        assert_eq!(presig.len(), 96);
+
+        // sig_offset in signers section should be 96
+        let sig_offset = u32::from_le_bytes(presig[76..80].try_into().unwrap());
+        assert_eq!(sig_offset, 96);
+
+        // Total finalized payload length should be 96 + 64 = 160 bytes
+        assert_eq!(finalized.len(), 160);
+        assert_eq!(&finalized[..96], &presig[..]);
+
+        // Tail contains the produced signature
+        assert_eq!(&finalized[96..], &signed_sig[..]);
+
+        // Digest verified against secp256k1 Schnorr
+        let expected_digest = compute_sig_message(&rest_preimage, &presig);
+        let msg = secp256k1::Message::from_digest(expected_digest);
+        let xonly = secp256k1::XOnlyPublicKey::from_slice(&signer.pubkey()).unwrap();
+        let sig = secp256k1::schnorr::Signature::from_slice(&signed_sig).unwrap();
+        assert!(secp256k1::SECP256K1.verify_schnorr(&sig, &msg, &xonly).is_ok());
+
+        // Validate that battery decode_ix decodes the payload ix data successfully
+        let access_prefix_len = 70;
+        let ix_data = &finalized[access_prefix_len..];
+        let decoded = decode_ix(ix_data, 2).unwrap();
+        assert_eq!(decoded.signers.len(), 1);
+        assert_eq!(decoded.actions.len(), 1);
+        assert_eq!(access_prefix_len + decoded.end_of_actions_in_ix, presig.len());
+    }
+
+    #[test]
+    fn test_two_signers_two_actions_mixed_tail() {
+        let signer1 = Bip340Signer::new();
+        let res0 = [0x01u8; 32];
+        let res1 = [0x02u8; 32];
+
+        let prev_rest = vec![0xaa; 40];
+        let prev_digest = [0xbb; 32];
+
+        // Action 1: Transfer action from 0 to 1 with amount 16
+        let action1 = vec![0x03, 0x00, 0x01, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        // Action 2: Transfer action from 1 to 0 with amount 32
+        let action2 = vec![0x03, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let payload_builder = LanePayload::new()
+            .access(AccessMetadata { resource_id: res0.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: res1.into(), access_type: AccessType::Read })
+            .action(action1)
+            .action(action2)
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            })
+            .signer(SignerSpec {
+                resource_idx: 1,
+                kind: SignerKind::Witness { tag: PrevTxV1WitnessSigner::TAG, input_idx: 2 },
+                tail: TailBlock::Witness {
+                    prev_rest_preimage: prev_rest.clone(),
+                    prev_payload_digest: prev_digest,
+                },
+            });
+
+        let presig = payload_builder.presig();
+        let rest = [0x99u8; 20];
+        let mut signed_sig = [0u8; 64];
+        let finalized = payload_builder.finish(&rest, &mut |req| {
+            assert_eq!(req.signer, 0);
+            signed_sig = signer1.sign_digest(req.digest);
+            signed_sig
+        });
+
+        // Tail layout:
+        // presig_len -> 64 bytes (signer 0 Sig64) -> 40 bytes (signer 1 rp) -> 32 bytes (signer 1
+        // pd)
+        let presig_len = presig.len();
+        assert_eq!(finalized.len(), presig_len + 64 + 40 + 32);
+
+        // Signer 0 sig_offset points to presig_len
+        // Signer 1 rp_offset points to presig_len + 64, rp_len = 40, pd_offset = presig_len + 64 +
+        // 40
+        let sig0_slice = &finalized[presig_len..presig_len + 64];
+        let witness_rp_slice = &finalized[presig_len + 64..presig_len + 64 + 40];
+        let witness_pd_slice = &finalized[presig_len + 64 + 40..];
+
+        assert_eq!(witness_rp_slice, &prev_rest[..]);
+        assert_eq!(witness_pd_slice, &prev_digest[..]);
+        assert_eq!(sig0_slice, &signed_sig[..]);
+
+        let digest = compute_sig_message(&rest, &presig);
+        let msg = secp256k1::Message::from_digest(digest);
+        let xonly = secp256k1::XOnlyPublicKey::from_slice(&signer1.pubkey()).unwrap();
+        let sig = secp256k1::schnorr::Signature::from_slice(&signed_sig).unwrap();
+        assert!(secp256k1::SECP256K1.verify_schnorr(&sig, &msg, &xonly).is_ok());
+
+        // Validate that battery decode_ix decodes the payload ix data successfully
+        let access_prefix_len = 4 + 2 * 33;
+        let ix_data = &finalized[access_prefix_len..];
+        let decoded = decode_ix(ix_data, 2).unwrap();
+        assert_eq!(decoded.signers.len(), 2);
+        assert_eq!(decoded.actions.len(), 2);
+        assert_eq!(access_prefix_len + decoded.end_of_actions_in_ix, presig.len());
+    }
+
+    #[test]
+    fn test_adversarial_n_signers_ordering_and_indices() {
+        let signer_a = Bip340Signer::new();
+        let signer_b = Bip340Signer::new();
+        let signer_c = Bip340Signer::new();
+
+        let res0 = [0x01u8; 32];
+        let res1 = [0x02u8; 32];
+        let res2 = [0x03u8; 32];
+
+        let witness_rest1 = vec![0x11; 50];
+        let witness_digest1 = [0x22; 32];
+        let witness_rest2 = vec![0x33; 30];
+        let witness_digest2 = [0x44; 32];
+
+        // 5 signers on resources 0, 0, 1, 2, 2 (non-strict ascending order)
+        let payload_builder = LanePayload::new()
+            .access(AccessMetadata { resource_id: res0.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: res1.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: res2.into(), access_type: AccessType::Read })
+            .action(vec![0x03, 0x00, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            })
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::MultisigSigPtr {
+                    tag: MultisigSchnorrSigPtrSigner::TAG,
+                    pubkey_idx: 1,
+                },
+                tail: TailBlock::Sig64,
+            })
+            .signer(SignerSpec {
+                resource_idx: 1,
+                kind: SignerKind::Witness { tag: PrevTxV1WitnessSigner::TAG, input_idx: 0 },
+                tail: TailBlock::Witness {
+                    prev_rest_preimage: witness_rest1.clone(),
+                    prev_payload_digest: witness_digest1,
+                },
+            })
+            .signer(SignerSpec {
+                resource_idx: 2,
+                kind: SignerKind::SigPtr { tag: GenesisSchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            })
+            .signer(SignerSpec {
+                resource_idx: 2,
+                kind: SignerKind::Witness { tag: PrevTxV1WitnessSigner::TAG, input_idx: 1 },
+                tail: TailBlock::Witness {
+                    prev_rest_preimage: witness_rest2.clone(),
+                    prev_payload_digest: witness_digest2,
+                },
+            });
+
+        let mut seen_indices = Vec::new();
+        let finalized = payload_builder.finish(&[0xaa; 32], &mut |req| {
+            seen_indices.push(req.signer);
+            match req.signer {
+                0 => signer_a.sign_digest(req.digest),
+                1 => signer_b.sign_digest(req.digest),
+                3 => signer_c.sign_digest(req.digest),
+                other => panic!("unexpected signer index {other}"),
+            }
+        });
+
+        // 3 signature slots requested: signer index 0, 1, and 3
+        assert_eq!(seen_indices, vec![0, 1, 3]);
+
+        // decode_ix successfully parses all 5 signers in order
+        let access_prefix_len = 4 + 3 * 33;
+        let ix_data = &finalized[access_prefix_len..];
+        let decoded = decode_ix(ix_data, 3).unwrap();
+        assert_eq!(decoded.signers.len(), 5);
+        assert_eq!(decoded.signers[0].0, 0);
+        assert_eq!(decoded.signers[1].0, 0);
+        assert_eq!(decoded.signers[2].0, 1);
+        assert_eq!(decoded.signers[3].0, 2);
+        assert_eq!(decoded.signers[4].0, 2);
+    }
+
+    #[test]
+    fn test_finish_length_invariant_to_rest_preimage() {
+        let signer = Bip340Signer::new();
+        let payload_builder = LanePayload::new()
+            .access(AccessMetadata {
+                resource_id: [0x12u8; 32].into(),
+                access_type: AccessType::Write,
+            })
+            .action(vec![0x01, 0x02, 0x03])
+            .signer(SignerSpec {
+                resource_idx: 0,
+                kind: SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+                tail: TailBlock::Sig64,
+            });
+
+        let out1 = payload_builder.finish(&[], &mut |req| signer.sign_digest(req.digest));
+        let out2 = payload_builder.finish(&[0x11; 50], &mut |req| signer.sign_digest(req.digest));
+        let out3 = payload_builder.finish(&[0x22; 256], &mut |req| signer.sign_digest(req.digest));
+
+        assert_eq!(out1.len(), out2.len());
+        assert_eq!(out2.len(), out3.len());
+    }
+
+    #[test]
+    fn test_empty_signers_deposit_shape() {
+        let user_id = [0xaa; 32];
+        let config_id = [0xcc; 32];
+        let deposit_action = vec![0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let payload_builder = LanePayload::new()
+            .access(AccessMetadata { resource_id: user_id.into(), access_type: AccessType::Write })
+            .access(AccessMetadata { resource_id: config_id.into(), access_type: AccessType::Read })
+            .action(deposit_action.clone());
+
+        let payload = payload_builder.finish_unsigned();
+
+        // access_meta: 4 bytes + 2 * 33 bytes = 70 bytes
+        // signers: 4 bytes (0 count)
+        // actions: 4 bytes (1 count) + 6 bytes body = 10 bytes
+        // total: 70 + 4 + 10 = 84 bytes
+        assert_eq!(payload.len(), 84);
+        assert_eq!(&payload[70..74], &[0, 0, 0, 0]); // 0 signers
+        assert_eq!(&payload[74..78], &[1, 0, 0, 0]); // 1 action
+        assert_eq!(&payload[78..], &deposit_action[..]);
+    }
+}

--- a/zk/backend/risc0/app-kit/src/signer.rs
+++ b/zk/backend/risc0/app-kit/src/signer.rs
@@ -1,0 +1,229 @@
+//! Signer specifications and cryptographic helpers for host-side lane payloads.
+//!
+//! Provides the [`SignerSpec`] descriptor, wire-tag constants from the runtime
+//! processor battery, and [`Bip340Signer`] for producing BIP-340 Schnorr signatures.
+
+use secp256k1::Keypair;
+pub use vprogs_zk_backend_risc0_runtime_processor::{
+    signer_trait::Signer,
+    signer_variants::{
+        GenesisSchnorrSigPtrSigner, MultisigPrevTxV1WitnessSigner, MultisigSchnorrSigPtrSigner,
+        PrevTxV1WitnessSigner, SchnorrSigPtrSigner,
+    },
+};
+
+/// The tail block a signer's pointers reference: a 64-byte BIP-340 signature the
+/// caller produces, or a prev-tx witness (`rest_preimage || payload_digest(32)`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TailBlock {
+    /// A 64-byte signature slot, filled by the signing closure in
+    /// [`LanePayload::finish`](crate::payload::LanePayload::finish).
+    Sig64,
+    /// A witness block carried verbatim into the tail.
+    Witness {
+        /// The serialized `rest_preimage` of the funding transaction.
+        prev_rest_preimage: Vec<u8>,
+        /// The 32-byte payload digest of the funding transaction.
+        prev_payload_digest: [u8; 32],
+    },
+}
+
+/// One signer entry the assembler lays out: `resource_idx u8 || kind u8 || body`.
+///
+/// `tag` is a battery variant's `TAG`; an app-defined kind that shares a body
+/// layout (such as a custom genesis sig-pointer) supplies its own tag byte.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SignerKind {
+    /// Body `sig_offset u32` pointing to a [`TailBlock::Sig64`].
+    SigPtr {
+        /// Wire tag for the signer variant.
+        tag: u8,
+    },
+    /// Body `pubkey_idx u8 || sig_offset u32` pointing to a [`TailBlock::Sig64`].
+    MultisigSigPtr {
+        /// Wire tag for the signer variant.
+        tag: u8,
+        /// Index of the public key within the target multisig lock.
+        pubkey_idx: u8,
+    },
+    /// Body `input_idx u8 || rp_off u32 || rp_len u32 || pd_off u32` pointing to a
+    /// [`TailBlock::Witness`].
+    Witness {
+        /// Wire tag for the signer variant.
+        tag: u8,
+        /// Index of the carrier input that spends the authed output.
+        input_idx: u8,
+    },
+}
+
+/// A fully-described signer entry (kind and tail), minus the offsets the assembler computes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignerSpec {
+    /// Index of the target resource in the transaction's access list.
+    pub resource_idx: u8,
+    /// The wire kind and parameters for this signer.
+    pub kind: SignerKind,
+    /// The tail data block referenced by this signer.
+    pub tail: TailBlock,
+}
+
+/// A BIP-340 (secp256k1 Schnorr) keypair for signing lane payloads; the x-only
+/// public key is what a `SchnorrLockView` carries.
+#[derive(Clone)]
+pub struct Bip340Signer {
+    /// The underlying secp256k1 keypair.
+    keypair: Keypair,
+    /// 32-byte serialized x-only public key.
+    pubkey: [u8; 32],
+}
+
+impl Bip340Signer {
+    /// Creates a fresh random signer.
+    pub fn new() -> Self {
+        let keypair = Keypair::new(secp256k1::SECP256K1, &mut rand::thread_rng());
+        let pubkey = keypair.x_only_public_key().0.serialize();
+        Self { keypair, pubkey }
+    }
+
+    /// Creates a signer from an existing secret key.
+    pub fn from_secret_key(sk: &secp256k1::SecretKey) -> Self {
+        let keypair = Keypair::from_secret_key(secp256k1::SECP256K1, sk);
+        let pubkey = keypair.x_only_public_key().0.serialize();
+        Self { keypair, pubkey }
+    }
+
+    /// Returns the 32-byte x-only public key.
+    pub fn pubkey(&self) -> [u8; 32] {
+        self.pubkey
+    }
+
+    /// Signs a 32-byte digest, returning the 64-byte BIP-340 signature.
+    pub fn sign_digest(&self, digest: &[u8; 32]) -> [u8; 64] {
+        secp256k1::SECP256K1
+            .sign_schnorr(&secp256k1::Message::from_digest(*digest), &self.keypair)
+            .serialize()
+    }
+}
+
+impl Default for Bip340Signer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Encodes one signer entry given its resolved offsets.
+pub(crate) fn encode_signer_entry(
+    resource_idx: u8,
+    kind: &SignerKind,
+    sig_offset: u32,
+    witness_offsets: (u32, u32, u32),
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(resource_idx);
+    match kind {
+        SignerKind::SigPtr { tag } => {
+            out.push(*tag);
+            out.extend_from_slice(&sig_offset.to_le_bytes());
+        }
+        SignerKind::MultisigSigPtr { tag, pubkey_idx } => {
+            out.push(*tag);
+            out.push(*pubkey_idx);
+            out.extend_from_slice(&sig_offset.to_le_bytes());
+        }
+        SignerKind::Witness { tag, input_idx } => {
+            out.push(*tag);
+            out.push(*input_idx);
+            out.extend_from_slice(&witness_offsets.0.to_le_bytes());
+            out.extend_from_slice(&witness_offsets.1.to_le_bytes());
+            out.extend_from_slice(&witness_offsets.2.to_le_bytes());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bip340_signer_roundtrip() {
+        let signer = Bip340Signer::new();
+        let digest = [0x42u8; 32];
+        let sig_bytes = signer.sign_digest(&digest);
+
+        let msg = secp256k1::Message::from_digest(digest);
+        let xonly = secp256k1::XOnlyPublicKey::from_slice(&signer.pubkey()).unwrap();
+        let sig = secp256k1::schnorr::Signature::from_slice(&sig_bytes).unwrap();
+        assert!(secp256k1::SECP256K1.verify_schnorr(&sig, &msg, &xonly).is_ok());
+    }
+
+    #[test]
+    fn test_bip340_signer_from_secret_key() {
+        let sk = secp256k1::SecretKey::from_slice(&[0x01; 32]).unwrap();
+        let signer = Bip340Signer::from_secret_key(&sk);
+        let expected_keypair = Keypair::from_secret_key(secp256k1::SECP256K1, &sk);
+        assert_eq!(signer.pubkey(), expected_keypair.x_only_public_key().0.serialize());
+    }
+
+    #[test]
+    fn test_signer_kind_wire_encoding_parity() {
+        // SigPtr wire parity: resource_idx || TAG || sig_offset (LE u32)
+        let sig_ptr_bytes = encode_signer_entry(
+            3,
+            &SignerKind::SigPtr { tag: SchnorrSigPtrSigner::TAG },
+            0x12345678,
+            (0, 0, 0),
+        );
+        let mut expected_sig_ptr = vec![3, SchnorrSigPtrSigner::TAG];
+        expected_sig_ptr.extend_from_slice(&0x12345678u32.to_le_bytes());
+        assert_eq!(sig_ptr_bytes, expected_sig_ptr);
+
+        // Genesis SigPtr wire parity (tag 0x05)
+        let gen_ptr_bytes = encode_signer_entry(
+            0,
+            &SignerKind::SigPtr { tag: GenesisSchnorrSigPtrSigner::TAG },
+            0xaabbccdd,
+            (0, 0, 0),
+        );
+        let mut expected_gen_ptr = vec![0, GenesisSchnorrSigPtrSigner::TAG];
+        expected_gen_ptr.extend_from_slice(&0xaabbccddu32.to_le_bytes());
+        assert_eq!(gen_ptr_bytes, expected_gen_ptr);
+
+        // MultisigSigPtr wire parity: resource_idx || TAG || pubkey_idx || sig_offset (LE u32)
+        let multi_sig_bytes = encode_signer_entry(
+            2,
+            &SignerKind::MultisigSigPtr { tag: MultisigSchnorrSigPtrSigner::TAG, pubkey_idx: 1 },
+            0x20406080,
+            (0, 0, 0),
+        );
+        let mut expected_multi = vec![2, MultisigSchnorrSigPtrSigner::TAG, 1];
+        expected_multi.extend_from_slice(&0x20406080u32.to_le_bytes());
+        assert_eq!(multi_sig_bytes, expected_multi);
+
+        // Witness wire parity: resource_idx || TAG || input_idx || rp_off || rp_len || pd_off
+        let witness_bytes = encode_signer_entry(
+            1,
+            &SignerKind::Witness { tag: PrevTxV1WitnessSigner::TAG, input_idx: 4 },
+            0,
+            (100, 200, 300),
+        );
+        let mut expected_witness = vec![1, PrevTxV1WitnessSigner::TAG, 4];
+        expected_witness.extend_from_slice(&100u32.to_le_bytes());
+        expected_witness.extend_from_slice(&200u32.to_le_bytes());
+        expected_witness.extend_from_slice(&300u32.to_le_bytes());
+        assert_eq!(witness_bytes, expected_witness);
+
+        // Multisig witness wire parity (TAG 0x04)
+        let multi_witness_bytes = encode_signer_entry(
+            5,
+            &SignerKind::Witness { tag: MultisigPrevTxV1WitnessSigner::TAG, input_idx: 0 },
+            0,
+            (50, 60, 70),
+        );
+        let mut expected_multi_witness = vec![5, MultisigPrevTxV1WitnessSigner::TAG, 0];
+        expected_multi_witness.extend_from_slice(&50u32.to_le_bytes());
+        expected_multi_witness.extend_from_slice(&60u32.to_le_bytes());
+        expected_multi_witness.extend_from_slice(&70u32.to_le_bytes());
+        assert_eq!(multi_witness_bytes, expected_multi_witness);
+    }
+}


### PR DESCRIPTION
App-agnostic host-side issuer crate (`zk/backend/risc0/app-kit`) for app drivers.

Extracts the issuer tooling that previously lived only in `examples/tn10-runtime` into its own crate, so app drivers can issue lane transactions without copying the example or growing an `App` trait. Additive-only: new crate plus workspace manifest entries, nothing else in the tree changes; the runner stays issuer-free.

- two-pass `LanePayload` assembly: N signers / N actions / mixed sig+witness tail, section offsets probed then patched in place
- signer wire over the battery TAGs (`SigPtr`, `MultisigSigPtr`, `Witness`, genesis variant), BIP-340 signing over a single payload digest
- carrier composition via `l1/wallet::signed_carrier_transaction`, `fund_and_submit` with bounded transient-error retries
- dev genesis helpers (fixed test keypair, p2pk address)
