### PR TITLE
zk-abi, aggregate-prover, app-kit: permission claim builder and per-bundle exit feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8834,6 +8834,7 @@ dependencies = [
  "vprogs-scheduling-scheduler",
  "vprogs-storage-manager",
  "vprogs-storage-rocksdb-store",
+ "vprogs-zk-abi",
  "vprogs-zk-aggregate-prover",
  "vprogs-zk-backend-risc0-api",
  "vprogs-zk-backend-risc0-settler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9265,6 +9265,7 @@ dependencies = [
  "vprogs-zk-abi",
  "vprogs-zk-batch-prover",
  "vprogs-zk-transaction-prover",
+ "zerocopy",
 ]
 
 [[package]]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -34,6 +34,7 @@ vprogs-node-framework              = { workspace = true }
 vprogs-scheduling-scheduler        = { workspace = true }
 vprogs-storage-manager             = { workspace = true }
 vprogs-storage-rocksdb-store       = { workspace = true }
+vprogs-zk-abi                      = { workspace = true }
 vprogs-zk-aggregate-prover         = { workspace = true }
 vprogs-zk-backend-risc0-api        = { workspace = true, features = ["host"] }
 vprogs-zk-backend-risc0-settler    = { workspace = true }

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -32,6 +32,8 @@ pub use node::{
 pub use persistence::PersistedState;
 pub use start::{RunnerHandles, StartError, start_runner};
 pub use vprogs_scheduling_scheduler::{Indexer, ResourceIndexer};
+pub use vprogs_zk_abi::withdrawal::ExitLeaf;
+pub use vprogs_zk_aggregate_prover::ExitsForBundle;
 pub use wrpc::connect_wrpc;
 
 /// Top-level runner entry point for the binary: connect, load the guest ELFs named by `config`, and

--- a/runner/src/node.rs
+++ b/runner/src/node.rs
@@ -20,7 +20,7 @@ use std::{
 use kaspa_consensus_core::{network::NetworkId, subnets::SubnetworkId};
 use kaspa_hashes::Hash;
 use kaspa_wrpc_client::prelude::KaspaRpcClient;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use vprogs_core_atomics::AsyncQueue;
 use vprogs_l1_bridge::L1BridgeConfig;
 use vprogs_l1_types::SettlementInfo;
@@ -134,9 +134,9 @@ pub struct ProvingParams {
     /// Receiver on the bridge's covenant `last_settlement` watch, cloned for the aggregate prover
     /// so it re-aggregates a superseded suffix, or `None` to run without re-forming.
     pub settlement_rx: Option<watch::Receiver<Option<SettlementInfo>>>,
-    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// Sender on the exit-leaf channel driving client Merkle-path proof generation, or `None` if
     /// exit publishing is disabled.
-    pub exits_tx: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
+    pub exits_tx: Option<mpsc::UnboundedSender<Arc<ExitsForBundle>>>,
 }
 
 /// Builds and starts an execution-only [`RunnerNode`]: a zk `Vm` with no proving, the given store,

--- a/runner/src/node.rs
+++ b/runner/src/node.rs
@@ -28,7 +28,9 @@ use vprogs_node_framework::{Node, NodeConfig};
 use vprogs_scheduling_scheduler::{ExecutionConfig, Indexer, SchedulerState};
 use vprogs_storage_manager::StorageConfig;
 use vprogs_storage_rocksdb_store::RocksDbStore;
-use vprogs_zk_aggregate_prover::{AggregateProverConfig, ScheduledBundle, SettlementArtifact};
+use vprogs_zk_aggregate_prover::{
+    AggregateProverConfig, ExitsForBundle, ScheduledBundle, SettlementArtifact,
+};
 use vprogs_zk_backend_risc0_api::{Backend, ProofType, Receipt};
 use vprogs_zk_batch_prover::BatchProverConfig;
 use vprogs_zk_vm::{ProvingPipeline, Vm};
@@ -132,6 +134,9 @@ pub struct ProvingParams {
     /// Receiver on the bridge's covenant `last_settlement` watch, cloned for the aggregate prover
     /// so it re-aggregates a superseded suffix, or `None` to run without re-forming.
     pub settlement_rx: Option<watch::Receiver<Option<SettlementInfo>>>,
+    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// exit publishing is disabled.
+    pub exits_tx: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
 }
 
 /// Builds and starts an execution-only [`RunnerNode`]: a zk `Vm` with no proving, the given store,
@@ -183,6 +188,7 @@ pub fn build_proving_node(
             settlement_queue: Some(proving.sink),
             settlement: proving.settlement_rx,
             bundle_size: proving.bundle_size,
+            exits: proving.exits_tx,
         },
     );
     let vm = Vm::new(backend, pipeline);

--- a/runner/src/start.rs
+++ b/runner/src/start.rs
@@ -22,6 +22,7 @@ use vprogs_core_smt::EMPTY_HASH;
 use vprogs_l1_types::SettlementInfo;
 use vprogs_l1_wallet::Wallet;
 use vprogs_scheduling_scheduler::Indexer;
+use vprogs_zk_aggregate_prover::ExitsForBundle;
 use vprogs_zk_backend_risc0_api::{Backend, ProofType};
 use vprogs_zk_backend_risc0_settler::{
     CovenantState, SettlementMode, SettlementWorkerConfig, bootstrap_dev_covenant,
@@ -55,6 +56,8 @@ pub struct RunnerHandles {
     pub lane_subnet: SubnetworkId,
     /// The resolved covenant id the runner follows / settles.
     pub covenant_id: Hash,
+    /// Receiver on the per-bundle exit leaves watch channel.
+    pub exits_rx: watch::Receiver<Option<Arc<ExitsForBundle>>>,
 }
 
 /// Operator-facing start-up failure, as opposed to `ConfigError` (which is about parsing the
@@ -189,18 +192,27 @@ where
         persisted: &mut persisted,
     };
     if cfg.prove {
-        let (node, settler, covenant_id) = start_settlement(ctx).await?;
-        Ok(RunnerHandles { node, settler: Some(settler), lane_id, lane_subnet, covenant_id })
+        let (node, settler, covenant_id, exits_rx) = start_settlement(ctx).await?;
+        Ok(RunnerHandles {
+            node,
+            settler: Some(settler),
+            lane_id,
+            lane_subnet,
+            covenant_id,
+            exits_rx,
+        })
     } else {
-        let (node, covenant_id) = start_exec(ctx).await?;
-        Ok(RunnerHandles { node, settler: None, lane_id, lane_subnet, covenant_id })
+        let (node, covenant_id, exits_rx) = start_exec(ctx).await?;
+        Ok(RunnerHandles { node, settler: None, lane_id, lane_subnet, covenant_id, exits_rx })
     }
 }
 
 /// Builds the execution-only node per the start mode: fresh bootstrap (dev-pins under
 /// `RISC0_DEV_MODE`, real-pins otherwise), resume from persisted identity, or catch up to an
 /// existing covenant. The bridge tracks the covenant's settlements; nothing here settles.
-async fn start_exec<F>(ctx: StartContext<'_, F>) -> Result<(RunnerNode, Hash), StartError> {
+async fn start_exec<F>(
+    ctx: StartContext<'_, F>,
+) -> Result<(RunnerNode, Hash, watch::Receiver<Option<Arc<ExitsForBundle>>>), StartError> {
     // Exec mode runs no prover, so the deposit-address derivation is dropped unused.
     let StartContext {
         cfg,
@@ -295,7 +307,8 @@ async fn start_exec<F>(ctx: StartContext<'_, F>) -> Result<(RunnerNode, Hash), S
         ),
         indexer,
     );
-    Ok((node, covenant_id))
+    let (_exits_tx, exits_rx) = watch::channel(None::<Arc<ExitsForBundle>>);
+    Ok((node, covenant_id, exits_rx))
 }
 
 /// Builds the proving + settlement node per the start mode: fresh bootstrap (dev-pins under
@@ -304,7 +317,15 @@ async fn start_exec<F>(ctx: StartContext<'_, F>) -> Result<(RunnerNode, Hash), S
 /// node and spawns the settler on the node's batch sink.
 async fn start_settlement<F>(
     ctx: StartContext<'_, F>,
-) -> Result<(RunnerNode, (JoinHandle<()>, AtomicAsyncLatch), Hash), StartError>
+) -> Result<
+    (
+        RunnerNode,
+        (JoinHandle<()>, AtomicAsyncLatch),
+        Hash,
+        watch::Receiver<Option<Arc<ExitsForBundle>>>,
+    ),
+    StartError,
+>
 where
     F: FnOnce(&CovenantIdBytes) -> DepositSpkHash,
 {
@@ -454,6 +475,7 @@ where
     // settlement here; the settler (reader) detects a competitor advancing past its in-memory
     // tip.
     let (settlement_tx, settlement_rx) = watch::channel(None::<SettlementInfo>);
+    let (exits_tx, exits_rx) = watch::channel(None::<Arc<ExitsForBundle>>);
     // Seed the bridge with reorg headroom: pin the anchor only if it is already deep, else seed
     // seed_depth below the sink. The settler keeps the unmodified `start_from` (its own
     // resume/adopt semantics), so this only affects where the bridge roots its chain.
@@ -479,6 +501,7 @@ where
             sink: queue.clone(),
             bundle_size: 1..=usize::MAX,
             settlement_rx: Some(settlement_rx.clone()),
+            exits_tx: Some(exits_tx),
         },
         indexer,
     );
@@ -508,7 +531,7 @@ where
         covenant,
         shutdown.clone(),
     ));
-    Ok((node, (settler, shutdown), covenant_id))
+    Ok((node, (settler, shutdown), covenant_id, exits_rx))
 }
 
 /// Resolves the explicit block the bridge roots its fresh chain at, decoupled from the settler's

--- a/runner/src/start.rs
+++ b/runner/src/start.rs
@@ -16,7 +16,10 @@ use kaspa_rpc_core::{RpcBlock, api::rpc::RpcApi};
 use kaspa_seq_commit::hashing::lane_key;
 use kaspa_wrpc_client::prelude::KaspaRpcClient;
 use secp256k1::Keypair;
-use tokio::{sync::watch, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 use vprogs_core_atomics::AtomicAsyncLatch;
 use vprogs_core_smt::EMPTY_HASH;
 use vprogs_l1_types::SettlementInfo;
@@ -56,8 +59,14 @@ pub struct RunnerHandles {
     pub lane_subnet: SubnetworkId,
     /// The resolved covenant id the runner follows / settles.
     pub covenant_id: Hash,
-    /// Receiver on the per-bundle exit leaves watch channel.
-    pub exits_rx: watch::Receiver<Option<Arc<ExitsForBundle>>>,
+    /// Receiver on the per-bundle exit leaves channel.
+    ///
+    /// Delivers exits per bundle in order with no coalescing. Publication means the bundle
+    /// artifact was published, not confirmed on L1: confirmations come from the settlement
+    /// watch, joined on `new_state` / `permission_spk_hash`. In exec mode the sender is
+    /// dropped at startup, closing the channel: `recv()` yields `None` (treat that as terminal
+    /// silence).
+    pub exits_rx: mpsc::UnboundedReceiver<Arc<ExitsForBundle>>,
 }
 
 /// Operator-facing start-up failure, as opposed to `ConfigError` (which is about parsing the
@@ -212,7 +221,7 @@ where
 /// existing covenant. The bridge tracks the covenant's settlements; nothing here settles.
 async fn start_exec<F>(
     ctx: StartContext<'_, F>,
-) -> Result<(RunnerNode, Hash, watch::Receiver<Option<Arc<ExitsForBundle>>>), StartError> {
+) -> Result<(RunnerNode, Hash, mpsc::UnboundedReceiver<Arc<ExitsForBundle>>), StartError> {
     // Exec mode runs no prover, so the deposit-address derivation is dropped unused.
     let StartContext {
         cfg,
@@ -307,7 +316,7 @@ async fn start_exec<F>(
         ),
         indexer,
     );
-    let (_exits_tx, exits_rx) = watch::channel(None::<Arc<ExitsForBundle>>);
+    let (_exits_tx, exits_rx) = mpsc::unbounded_channel::<Arc<ExitsForBundle>>();
     Ok((node, covenant_id, exits_rx))
 }
 
@@ -322,7 +331,7 @@ async fn start_settlement<F>(
         RunnerNode,
         (JoinHandle<()>, AtomicAsyncLatch),
         Hash,
-        watch::Receiver<Option<Arc<ExitsForBundle>>>,
+        mpsc::UnboundedReceiver<Arc<ExitsForBundle>>,
     ),
     StartError,
 >
@@ -475,7 +484,7 @@ where
     // settlement here; the settler (reader) detects a competitor advancing past its in-memory
     // tip.
     let (settlement_tx, settlement_rx) = watch::channel(None::<SettlementInfo>);
-    let (exits_tx, exits_rx) = watch::channel(None::<Arc<ExitsForBundle>>);
+    let (exits_tx, exits_rx) = mpsc::unbounded_channel();
     // Seed the bridge with reorg headroom: pin the anchor only if it is already deep, else seed
     // seed_depth below the sink. The settler keeps the unmodified `start_from` (its own
     // resume/adopt semantics), so this only affects where the bridge roots its chain.

--- a/runner/tests/two_provers_contend.rs
+++ b/runner/tests/two_provers_contend.rs
@@ -1585,6 +1585,7 @@ async fn spawn_prover(
             // settler reconciles against, so a bundle a shorter competitor superseded still
             // settles.
             settlement_rx: Some(settlement_rx.clone()),
+            exits_tx: None,
         },
         None,
     );

--- a/sim/src/driver/l2_driver.rs
+++ b/sim/src/driver/l2_driver.rs
@@ -251,6 +251,7 @@ fn build_exec(
                 // aggregate worker's park self-heals when the minimum (> 1 here) leaves the ready
                 // prefix short.
                 bundle_size: proof_bundle_size..=proof_bundle_size,
+                exits: None,
             },
         );
         (pipeline, Some(queue))

--- a/zk/abi/src/lib.rs
+++ b/zk/abi/src/lib.rs
@@ -11,6 +11,7 @@ mod read;
 pub mod withdrawal {
     pub(crate) mod deposit_sink;
     pub(crate) mod exit_accumulator;
+    pub(crate) mod exit_leaf;
     pub(crate) mod exit_sink;
     pub(crate) mod exits;
     pub(crate) mod exits_iter;
@@ -20,6 +21,7 @@ pub mod withdrawal {
 
     pub use deposit_sink::DepositSink;
     pub use exit_accumulator::ExitAccumulator;
+    pub use exit_leaf::ExitLeaf;
     pub use exit_sink::ExitSink;
     pub use exits::Exits;
     pub use exits_iter::ExitsIter;

--- a/zk/abi/src/withdrawal/exit_leaf.rs
+++ b/zk/abi/src/withdrawal/exit_leaf.rs
@@ -1,10 +1,10 @@
 //! Owned exit-leaf form for host-side channels. `StandardSpk<'a>` borrows its buffer, which
 //! cannot cross an `await` point or a `watch` channel; this is the owned mirror. The canonical
-//! leaf preimage stays `StandardSpk::to_script_bytes()` -- `script_bytes` re-slices it verbatim.
+//! leaf preimage stays `StandardSpk::to_script_bytes()`; `script_bytes` re-slices it verbatim.
 
 use crate::withdrawal::standard_spk::StandardSpk;
 
-/// Owned exit-leaf form for host-side channels.
+/// Owned exit leaf pairing an on-chain destination script with a sompi payout amount.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExitLeaf {
     /// On-chain script bytes buffer sized for the largest supported script.

--- a/zk/abi/src/withdrawal/exit_leaf.rs
+++ b/zk/abi/src/withdrawal/exit_leaf.rs
@@ -1,0 +1,60 @@
+//! Owned exit-leaf form for host-side channels. `StandardSpk<'a>` borrows its buffer, which
+//! cannot cross an `await` point or a `watch` channel; this is the owned mirror. The canonical
+//! leaf preimage stays `StandardSpk::to_script_bytes()` -- `script_bytes` re-slices it verbatim.
+
+use crate::withdrawal::standard_spk::StandardSpk;
+
+/// Owned exit-leaf form for host-side channels.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExitLeaf {
+    /// On-chain script bytes buffer sized for the largest supported script.
+    script_bytes: [u8; 35],
+    /// Length of the active script bytes within `script_bytes`.
+    script_len: u8,
+    /// Exit payout amount in sompis.
+    pub amount: u64,
+}
+
+impl ExitLeaf {
+    /// Builds an owned leaf from a borrowed destination and payout amount.
+    pub fn from_pair(dest: StandardSpk<'_>, amount: u64) -> Self {
+        let bytes = dest.to_script_bytes();
+        let slice = bytes.as_ref();
+        let mut script_bytes = [0u8; 35];
+        script_bytes[..slice.len()].copy_from_slice(slice);
+        Self { script_bytes, script_len: slice.len() as u8, amount }
+    }
+
+    /// Returns the on-chain script bytes slice.
+    pub fn script_bytes(&self) -> &[u8] {
+        &self.script_bytes[..self.script_len as usize]
+    }
+
+    /// Reconstructs the borrowed destination view over this leaf's script bytes.
+    pub fn to_standard_spk(&self) -> StandardSpk<'_> {
+        StandardSpk::from_script(self.script_bytes()).expect("owned leaf decodes")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_all_standard_spk_kinds() {
+        let pk: &[u8; 32] = &[7u8; 32];
+        let ecdsa: &[u8; 33] = &[9u8; 33];
+        let sh: &[u8; 32] = &[3u8; 32];
+        for (spk, amount) in [
+            (StandardSpk::PubKey(pk), 1_000u64),
+            (StandardSpk::PubKeyEcdsa(ecdsa), 2_000),
+            (StandardSpk::ScriptHash(sh), 3_000),
+        ] {
+            let leaf = ExitLeaf::from_pair(spk, amount);
+            assert_eq!(leaf.script_bytes(), spk.to_script_bytes().as_ref());
+            assert_eq!(leaf.amount, amount);
+            let back = leaf.to_standard_spk();
+            assert_eq!(back, spk);
+        }
+    }
+}

--- a/zk/abi/src/withdrawal/standard_spk.rs
+++ b/zk/abi/src/withdrawal/standard_spk.rs
@@ -67,6 +67,20 @@ impl<'a> StandardSpk<'a> {
         }
     }
 
+    /// Parses a standard script destination from on-chain script bytes.
+    pub fn from_script(s: &'a [u8]) -> Result<Self> {
+        if s.len() == 34 && s[0] == op::DATA_32 && s[33] == op::CHECK_SIG {
+            Ok(Self::PubKey(s[1..33].try_into().expect("len 32")))
+        } else if s.len() == 35 && s[0] == op::DATA_33 && s[34] == op::CHECK_SIG_ECDSA {
+            Ok(Self::PubKeyEcdsa(s[1..34].try_into().expect("len 33")))
+        } else if s.len() == 35 && s[0] == op::BLAKE2B && s[1] == op::DATA_32 && s[34] == op::EQUAL
+        {
+            Ok(Self::ScriptHash(s[2..34].try_into().expect("len 32")))
+        } else {
+            Err(ErrorCode::InvalidExitSpk.into())
+        }
+    }
+
     /// Returns the on-chain `script_public_key` bytes for this destination.
     pub fn to_script_bytes(&self) -> ScriptBytes {
         match self {
@@ -113,20 +127,7 @@ mod host {
             if spk.version() != STANDARD_SPK_VERSION {
                 return Err(ErrorCode::InvalidExitSpk.into());
             }
-            let s = spk.script();
-            if s.len() == 34 && s[0] == op::DATA_32 && s[33] == op::CHECK_SIG {
-                Ok(Self::PubKey(s[1..33].try_into().expect("len 32")))
-            } else if s.len() == 35 && s[0] == op::DATA_33 && s[34] == op::CHECK_SIG_ECDSA {
-                Ok(Self::PubKeyEcdsa(s[1..34].try_into().expect("len 33")))
-            } else if s.len() == 35
-                && s[0] == op::BLAKE2B
-                && s[1] == op::DATA_32
-                && s[34] == op::EQUAL
-            {
-                Ok(Self::ScriptHash(s[2..34].try_into().expect("len 32")))
-            } else {
-                Err(ErrorCode::InvalidExitSpk.into())
-            }
+            Self::from_script(spk.script())
         }
     }
 }

--- a/zk/aggregate-prover/Cargo.toml
+++ b/zk/aggregate-prover/Cargo.toml
@@ -20,6 +20,7 @@ vprogs-storage-types.workspace         = true
 vprogs-zk-abi                          = { workspace = true, features = ["host"] }
 vprogs-zk-batch-prover.workspace       = true
 vprogs-zk-transaction-prover.workspace = true
+zerocopy                               = { workspace = true, default-features = false }
 
 [dev-dependencies]
 tempfile.workspace                     = true

--- a/zk/aggregate-prover/src/config.rs
+++ b/zk/aggregate-prover/src/config.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::{ops::RangeInclusive, sync::Arc};
 
 use kaspa_hashes::Hash;
 use tokio::sync::watch;
@@ -6,7 +6,7 @@ use vprogs_core_atomics::AsyncQueue;
 use vprogs_l1_types::SettlementInfo;
 use vprogs_zk_batch_prover::LaneProofSource;
 
-use crate::{ScheduledBundle, SettlementArtifact};
+use crate::{ExitsForBundle, ScheduledBundle, SettlementArtifact};
 
 /// Static configuration for the aggregate prover.
 ///
@@ -35,4 +35,19 @@ pub struct AggregateProverConfig<L: LaneProofSource, R: Send + Sync + 'static> {
     /// capped at `*end()`. `1..=usize::MAX` ("1..") is the greedy default: form as soon as the
     /// front is ready and extend over every consecutively-ready batch.
     pub bundle_size: RangeInclusive<usize>,
+    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// exit publishing is disabled.
+    pub exits: Option<watch::Sender<Arc<ExitsForBundle>>>,
+}
+
+impl<L: LaneProofSource, R: Send + Sync + 'static> AggregateProverConfig<L, R> {
+    /// Sets the `watch` sender the aggregate worker publishes per-bundle exit leaves into. `None`
+    /// disables publishing.
+    pub fn with_exits_observer(
+        mut self,
+        exits: impl Into<Option<watch::Sender<Arc<ExitsForBundle>>>>,
+    ) -> Self {
+        self.exits = exits.into();
+        self
+    }
 }

--- a/zk/aggregate-prover/src/config.rs
+++ b/zk/aggregate-prover/src/config.rs
@@ -1,7 +1,7 @@
 use std::{ops::RangeInclusive, sync::Arc};
 
 use kaspa_hashes::Hash;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use vprogs_core_atomics::AsyncQueue;
 use vprogs_l1_types::SettlementInfo;
 use vprogs_zk_batch_prover::LaneProofSource;
@@ -35,9 +35,9 @@ pub struct AggregateProverConfig<L: LaneProofSource, R: Send + Sync + 'static> {
     /// capped at `*end()`. `1..=usize::MAX` ("1..") is the greedy default: form as soon as the
     /// front is ready and extend over every consecutively-ready batch.
     pub bundle_size: RangeInclusive<usize>,
-    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// Sender on the exit-leaf channel driving client Merkle-path proof generation, or `None` if
     /// exit publishing is disabled.
-    pub exits: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
+    pub exits: Option<mpsc::UnboundedSender<Arc<ExitsForBundle>>>,
 }
 
 impl<L: LaneProofSource, R: Send + Sync + 'static> AggregateProverConfig<L, R> {

--- a/zk/aggregate-prover/src/config.rs
+++ b/zk/aggregate-prover/src/config.rs
@@ -39,15 +39,3 @@ pub struct AggregateProverConfig<L: LaneProofSource, R: Send + Sync + 'static> {
     /// exit publishing is disabled.
     pub exits: Option<mpsc::UnboundedSender<Arc<ExitsForBundle>>>,
 }
-
-impl<L: LaneProofSource, R: Send + Sync + 'static> AggregateProverConfig<L, R> {
-    /// Sets the `watch` sender the aggregate worker publishes per-bundle exit leaves into. `None`
-    /// disables publishing.
-    pub fn with_exits_observer(
-        mut self,
-        exits: impl Into<Option<watch::Sender<Option<Arc<ExitsForBundle>>>>>,
-    ) -> Self {
-        self.exits = exits.into();
-        self
-    }
-}

--- a/zk/aggregate-prover/src/config.rs
+++ b/zk/aggregate-prover/src/config.rs
@@ -37,7 +37,7 @@ pub struct AggregateProverConfig<L: LaneProofSource, R: Send + Sync + 'static> {
     pub bundle_size: RangeInclusive<usize>,
     /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
     /// exit publishing is disabled.
-    pub exits: Option<watch::Sender<Arc<ExitsForBundle>>>,
+    pub exits: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
 }
 
 impl<L: LaneProofSource, R: Send + Sync + 'static> AggregateProverConfig<L, R> {
@@ -45,7 +45,7 @@ impl<L: LaneProofSource, R: Send + Sync + 'static> AggregateProverConfig<L, R> {
     /// disables publishing.
     pub fn with_exits_observer(
         mut self,
-        exits: impl Into<Option<watch::Sender<Arc<ExitsForBundle>>>>,
+        exits: impl Into<Option<watch::Sender<Option<Arc<ExitsForBundle>>>>>,
     ) -> Self {
         self.exits = exits.into();
         self

--- a/zk/aggregate-prover/src/exit_feed.rs
+++ b/zk/aggregate-prover/src/exit_feed.rs
@@ -13,7 +13,9 @@ pub struct ExitsForBundle {
     pub new_state: [u8; 32],
     /// Hash of the permission redeem script, or `[0u8; 32]` if no exits were emitted.
     pub permission_spk_hash: [u8; 32],
-    /// Owned exit leaves extracted in batch and journal order.
+    /// Owned exit leaves extracted in batch and journal order. The bundle's complete canonical
+    /// leaf list for that root (per-bundle tree; never empty when published: the worker suppresses
+    /// zero-hash bundles).
     pub leaves: Arc<Vec<ExitLeaf>>,
 }
 

--- a/zk/aggregate-prover/src/exit_feed.rs
+++ b/zk/aggregate-prover/src/exit_feed.rs
@@ -1,0 +1,101 @@
+//! Host-side exit-leaf feed. The guest accumulator folds exits inside the aggregator proof;
+//! the host replays the same leaves from batch journals so clients can build merkle paths.
+
+use std::sync::Arc;
+
+use vprogs_zk_abi::{Error, batch_processor::BatchTransition, withdrawal::ExitLeaf};
+use zerocopy::FromBytes;
+
+/// Bundle exits extracted from batch journals alongside the state root and permission hash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExitsForBundle {
+    /// L2 SMT state root after this bundle.
+    pub new_state: [u8; 32],
+    /// Hash of the permission redeem script, or `[0u8; 32]` if no exits were emitted.
+    pub permission_spk_hash: [u8; 32],
+    /// Owned exit leaves extracted in batch and journal order.
+    pub leaves: Arc<Vec<ExitLeaf>>,
+}
+
+/// Decodes trailing exits from a sequence of batch journals in bundle order.
+pub fn extract_bundle_exits(journals: &[Vec<u8>]) -> Result<Vec<ExitLeaf>, Error> {
+    let mut leaves = Vec::new();
+    for journal in journals {
+        let transition = BatchTransition::ref_from_bytes(journal.as_slice())
+            .map_err(|e| Error::Decode(format!("{e}")))?;
+        for pair in &transition.exits {
+            let (dest, amount) = pair?;
+            leaves.push(ExitLeaf::from_pair(dest, amount));
+        }
+    }
+    Ok(leaves)
+}
+
+#[cfg(test)]
+mod tests {
+    use kaspa_hashes::Hash;
+    use vprogs_zk_abi::{
+        batch_processor::{BatchTransition, BatchTransitionArgs},
+        withdrawal::StandardSpk,
+    };
+
+    use super::*;
+
+    fn journal_with_exits(pairs: &[(Vec<u8>, u64)]) -> Vec<u8> {
+        let mut exits_buf = Vec::new();
+        for (script_bytes, amount) in pairs {
+            let spk = StandardSpk::from_script(script_bytes).expect("valid script");
+            spk.encode(&mut exits_buf);
+            exits_buf.extend_from_slice(&amount.to_le_bytes());
+        }
+        let mut buf = Vec::new();
+        BatchTransition::encode(
+            &mut buf,
+            BatchTransitionArgs {
+                prev_state: &[0u8; 32],
+                prev_lane_tip: &Hash::default(),
+                prev_lane_blue_score: 0,
+                new_state: &[0u8; 32],
+                new_lane_tip: &Hash::default(),
+                new_lane_blue_score: 0,
+                lane_key: &Hash::default(),
+                covenant_id: &[0u8; 32],
+                tx_image_id: &[0u8; 32],
+                deposit_spk_hash: &[0u8; 32],
+                lane_expired: false,
+                exits: &exits_buf,
+            },
+        );
+        buf
+    }
+
+    #[test]
+    fn extracts_leaves_in_journal_order() {
+        let a: Vec<u8> = StandardSpk::PubKey(&[1u8; 32]).to_script_bytes().as_ref().to_vec();
+        let b: Vec<u8> = StandardSpk::ScriptHash(&[2u8; 32]).to_script_bytes().as_ref().to_vec();
+        let j1 = journal_with_exits(&[(a.clone(), 100), (b.clone(), 200)]);
+        let j2 = journal_with_exits(&[(a.clone(), 300)]);
+        let leaves = extract_bundle_exits(&[j1, j2]).unwrap();
+        assert_eq!(leaves.len(), 3);
+        assert_eq!(leaves[0].amount, 100);
+        assert_eq!(leaves[0].script_bytes(), a.as_slice());
+        assert_eq!(leaves[1].amount, 200);
+        assert_eq!(leaves[2].amount, 300);
+    }
+
+    #[test]
+    fn handles_empty_bundle_and_empty_exits() {
+        let empty_bundle = extract_bundle_exits(&[]).unwrap();
+        assert!(empty_bundle.is_empty());
+
+        let j_no_exits = journal_with_exits(&[]);
+        let empty_leaves = extract_bundle_exits(&[j_no_exits.clone(), j_no_exits]).unwrap();
+        assert!(empty_leaves.is_empty());
+    }
+
+    #[test]
+    fn rejects_truncated_journal() {
+        let bad = vec![0u8; 10];
+        assert!(extract_bundle_exits(&[bad]).is_err());
+    }
+}

--- a/zk/aggregate-prover/src/lib.rs
+++ b/zk/aggregate-prover/src/lib.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod command;
 mod config;
+mod exit_feed;
 mod prover;
 mod scheduled_bundle;
 mod settlement_artifact;
@@ -8,6 +9,7 @@ mod worker;
 
 pub use backend::Backend;
 pub use config::AggregateProverConfig;
+pub use exit_feed::{ExitsForBundle, extract_bundle_exits};
 pub use prover::AggregateProver;
 pub use scheduled_bundle::{BundleBlocks, ScheduledBundle};
 pub use settlement_artifact::SettlementArtifact;

--- a/zk/aggregate-prover/src/worker.rs
+++ b/zk/aggregate-prover/src/worker.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use kaspa_hashes::Hash;
-use tokio::{runtime::Builder, sync::watch};
+use tokio::{
+    runtime::Builder,
+    sync::{mpsc, watch},
+};
 use vprogs_core_atomics::AsyncQueue;
 use vprogs_core_codec::Reader;
 use vprogs_l1_types::{ChainBlockMetadata, SettlementInfo};
@@ -52,9 +55,9 @@ pub(crate) struct Worker<S: Store, P: Processor<S>, B: Backend, L: LaneProofSour
     /// First-batch checkpoint index of the most recently re-formed suffix, guarding against
     /// re-emitting it on every settlement wake. Reset by a rollback.
     last_reformed_from: Option<u64>,
-    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// Sender on the exit-leaf channel driving client Merkle-path proof generation, or `None` if
     /// exit publishing is disabled.
-    exits: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
+    exits: Option<mpsc::UnboundedSender<Arc<ExitsForBundle>>>,
 }
 
 impl<S, P, B, L> Worker<S, P, B, L>
@@ -387,11 +390,12 @@ where
             if st.permission_spk_hash != [0u8; 32] {
                 let leaves =
                     Arc::new(extract_bundle_exits(&journals).expect("decode bundle exits"));
-                sender.send_replace(Some(Arc::new(ExitsForBundle {
+                // Receiver dropped means no consumer is listening; silently ignore.
+                let _ = sender.send(Arc::new(ExitsForBundle {
                     new_state: st.new_state,
                     permission_spk_hash: st.permission_spk_hash,
                     leaves,
-                })));
+                }));
             }
         }
     }

--- a/zk/aggregate-prover/src/worker.rs
+++ b/zk/aggregate-prover/src/worker.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     ops::RangeInclusive,
+    sync::Arc,
     thread::{JoinHandle, spawn},
 };
 
@@ -15,8 +16,8 @@ use vprogs_zk_abi::batch_aggregator::{Inputs as AggregatorInputs, StateTransitio
 use vprogs_zk_batch_prover::{LaneProofRequest, LaneProofSource};
 
 use crate::{
-    AggregateProver, AggregateProverConfig, Backend, BundleBlocks, ScheduledBundle,
-    SettlementArtifact, command::Command,
+    AggregateProver, AggregateProverConfig, Backend, BundleBlocks, ExitsForBundle, ScheduledBundle,
+    SettlementArtifact, command::Command, extract_bundle_exits,
 };
 
 /// Background worker that accumulates scheduled batches, forms bundles from the consecutively-ready
@@ -51,6 +52,9 @@ pub(crate) struct Worker<S: Store, P: Processor<S>, B: Backend, L: LaneProofSour
     /// First-batch checkpoint index of the most recently re-formed suffix, guarding against
     /// re-emitting it on every settlement wake. Reset by a rollback.
     last_reformed_from: Option<u64>,
+    /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
+    /// exit publishing is disabled.
+    exits: Option<watch::Sender<Arc<ExitsForBundle>>>,
 }
 
 impl<S, P, B, L> Worker<S, P, B, L>
@@ -81,6 +85,7 @@ where
             settlement_queue,
             settlement,
             bundle_size,
+            exits,
         } = config;
         // Bundle formation parks while `take` is below the range start and caps `take` at the range
         // end, so an empty range (start > end) would never form a bundle. Reject it up front rather
@@ -101,6 +106,7 @@ where
             retained: VecDeque::new(),
             settlement,
             last_reformed_from: None,
+            exits,
         };
         let runtime = Builder::new_current_thread().enable_all().build().expect("runtime");
         spawn(move || runtime.block_on(this.run()))
@@ -292,6 +298,7 @@ where
         let seq_commit = last_metadata.seq_commit.as_bytes();
         let agg_key = handle.agg_key(*self.backend.aggregator_image_id(), seq_commit);
         let receipt_store = &self.prover.receipt_store;
+        let journals: Vec<Vec<u8>> = receipts.iter().map(|r| B::journal_bytes(r)).collect();
         let receipt = match receipt_store.read_agg_receipt(agg_key).resolve().await {
             Some(receipt) => receipt,
             None => {
@@ -305,7 +312,6 @@ where
                         lane_key: self.lane_key,
                     })
                     .await;
-                let journals: Vec<Vec<u8>> = receipts.iter().map(|r| B::journal_bytes(r)).collect();
                 let inputs = AggregatorInputs::encode(
                     self.backend.batch_image_id(),
                     &lane_proof,
@@ -375,6 +381,19 @@ where
             covenant_id: st.covenant_id,
         };
         handle.publish_artifact(Some(artifact));
+
+        // Publish exit leaves for client Merkle-path generation when exits were emitted.
+        if let Some(sender) = &self.exits {
+            if st.permission_spk_hash != [0u8; 32] {
+                let leaves =
+                    Arc::new(extract_bundle_exits(&journals).expect("decode bundle exits"));
+                sender.send_replace(Arc::new(ExitsForBundle {
+                    new_state: st.new_state,
+                    permission_spk_hash: st.permission_spk_hash,
+                    leaves,
+                }));
+            }
+        }
     }
 
     /// Publishes a formed bundle's handle onto the settlement queue, if one is wired. With no queue

--- a/zk/aggregate-prover/src/worker.rs
+++ b/zk/aggregate-prover/src/worker.rs
@@ -54,7 +54,7 @@ pub(crate) struct Worker<S: Store, P: Processor<S>, B: Backend, L: LaneProofSour
     last_reformed_from: Option<u64>,
     /// Sender on the exit-leaf watch driving client Merkle-path proof generation, or `None` if
     /// exit publishing is disabled.
-    exits: Option<watch::Sender<Arc<ExitsForBundle>>>,
+    exits: Option<watch::Sender<Option<Arc<ExitsForBundle>>>>,
 }
 
 impl<S, P, B, L> Worker<S, P, B, L>
@@ -387,11 +387,11 @@ where
             if st.permission_spk_hash != [0u8; 32] {
                 let leaves =
                     Arc::new(extract_bundle_exits(&journals).expect("decode bundle exits"));
-                sender.send_replace(Arc::new(ExitsForBundle {
+                sender.send_replace(Some(Arc::new(ExitsForBundle {
                     new_state: st.new_state,
                     permission_spk_hash: st.permission_spk_hash,
                     leaves,
-                }));
+                })));
             }
         }
     }

--- a/zk/aggregate-prover/tests/canceled_batch_bundle.rs
+++ b/zk/aggregate-prover/tests/canceled_batch_bundle.rs
@@ -231,6 +231,7 @@ fn canceled_batch_is_not_swept_into_a_bundle() {
                 settlement_queue: Some(settlement_queue.clone()),
                 settlement: None,
                 bundle_size: 1..=usize::MAX,
+                exits: None,
             },
         );
         prover.submit(&front);
@@ -331,6 +332,7 @@ fn whole_canceled_queue_is_evicted() {
                 settlement_queue: Some(settlement_queue.clone()),
                 settlement: None,
                 bundle_size: 1..=usize::MAX,
+                exits: None,
             },
         );
         prover.submit(&never_published);

--- a/zk/aggregate-prover/tests/noop_bundle_classification.rs
+++ b/zk/aggregate-prover/tests/noop_bundle_classification.rs
@@ -363,6 +363,7 @@ fn bundle_advancing_only_the_lane_tip_is_settled() {
                 settlement_queue: Some(settlement_queue.clone()),
                 settlement: None,
                 bundle_size: 1..=usize::MAX,
+                exits: None,
             },
         );
         prover.submit(&batch);

--- a/zk/backend/risc0/app-kit/src/claim.rs
+++ b/zk/backend/risc0/app-kit/src/claim.rs
@@ -76,7 +76,8 @@ pub struct PermissionSpendArgs<'a> {
     pub new_unclaimed: u64,
     /// Delegate funding inputs paying into the spend and covering transaction fees.
     pub delegate_inputs: Vec<(TransactionOutpoint, u64)>,
-    /// Transaction fee in sompis.
+    /// Transaction fee in sompis. Admission-only and not subtracted from outputs; built
+    /// transactions are zero-fee on-chain and may fail min-relay-fee policy outside simnet.
     pub fee: u64,
 }
 
@@ -89,8 +90,8 @@ pub fn build_permission_spend(
     }
 
     let total_delegate: u64 = args.delegate_inputs.iter().map(|(_, a)| *a).sum();
-    if total_delegate + args.permission_rent < args.deduct + args.fee {
-        return Err("insufficient input value for deduct and fee");
+    if total_delegate < args.deduct {
+        return Err("insufficient delegate input value for deduct");
     }
     if args.delegate_inputs.len() > MAX_DELEGATE_INPUTS {
         return Err("too many delegate inputs");
@@ -175,6 +176,8 @@ pub fn build_permission_spend(
 }
 
 /// Computes sibling paths against the padded permission tree for a leaf index.
+///
+/// Requires `index < 1 << required_depth(leaves.len())` (panics otherwise).
 pub fn claim_siblings(leaves: &[ExitLeaf], index: usize) -> Vec<[u8; 32]> {
     let depth = PermissionTreeAccumulator::required_depth(leaves.len());
     let capacity = 1usize << depth;
@@ -380,6 +383,8 @@ mod tests {
             fee: 1_000,
         };
         let (tx, utxos) = build_permission_spend(&args).unwrap();
+        assert_eq!(tx.outputs.len(), 1);
+        assert_eq!(tx.outputs[0].value, 7_000 + 50_000_000);
         run_spend(&tx, &utxos).expect("full claim verifies");
     }
 
@@ -475,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn builder_rejects_insufficient_value() {
+    fn builder_rejects_delegate_shortfall() {
         let spk = test_spk(7);
         let args = PermissionSpendArgs {
             covenant_id: [0xFF; 32],
@@ -491,12 +496,12 @@ mod tests {
             siblings: vec![[0; 32]],
             new_root: [0; 32],
             new_unclaimed: 1,
-            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 1_000)],
-            fee: 50_000_000,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 1_500)],
+            fee: 0,
         };
         assert_eq!(
             build_permission_spend(&args).unwrap_err(),
-            "insufficient input value for deduct and fee"
+            "insufficient delegate input value for deduct"
         );
     }
 }

--- a/zk/backend/risc0/app-kit/src/claim.rs
+++ b/zk/backend/risc0/app-kit/src/claim.rs
@@ -196,8 +196,8 @@ pub fn claim_siblings(leaves: &[ExitLeaf], index: usize) -> Vec<[u8; 32]> {
     }
     let mut out = Vec::with_capacity(depth);
     let mut idx = index;
-    for level in 0..depth {
-        out.push(nodes[level][idx ^ 1]);
+    for level in nodes.iter().take(depth) {
+        out.push(level[idx ^ 1]);
         idx /= 2;
     }
     out

--- a/zk/backend/risc0/app-kit/src/claim.rs
+++ b/zk/backend/risc0/app-kit/src/claim.rs
@@ -1,0 +1,502 @@
+//! Host-side claim builder for settled exits in the on-chain permission tree.
+
+use kaspa_consensus_core::{
+    constants::TX_VERSION_TOCCATA,
+    subnets::SUBNETWORK_ID_NATIVE,
+    tx::{
+        CovenantBinding, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint,
+        TransactionOutput, UtxoEntry,
+    },
+};
+use kaspa_hashes::Hash;
+use kaspa_txscript::{
+    EngineFlags, script_builder::ScriptBuilder, standard::pay_to_script_hash_script,
+};
+use vprogs_zk_abi::withdrawal::ExitLeaf;
+use vprogs_zk_backend_risc0_api::{
+    MAX_DELEGATE_INPUTS, PermissionTreeAccumulator, build_delegate_entry_script,
+    build_permission_redeem_script,
+};
+
+/// Assembles the permission input's signature script: the public withdrawal witness consumed
+/// by the redeem prefix.
+///
+/// Push order: new-root sibling walk (high to low: sibling data then direction bit), old-root walk,
+/// leaf spk, amount LE (8 bytes), deduct (script number), and redeem script bytes.
+pub fn permission_sig_script(
+    spk: &[u8],
+    amount: u64,
+    deduct: u64,
+    index: usize,
+    siblings: &[[u8; 32]],
+    redeem: &[u8],
+) -> Vec<u8> {
+    let mut b =
+        ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
+    for _walk in 0..2 {
+        for level in (0..siblings.len()).rev() {
+            b.add_data(&siblings[level]).unwrap();
+            b.add_i64(((index >> level) & 1) as i64).unwrap();
+        }
+    }
+    b.add_data(spk).unwrap();
+    b.add_data(&amount.to_le_bytes()).unwrap();
+    b.add_i64(deduct as i64).unwrap();
+    b.add_data(redeem).unwrap();
+    b.drain()
+}
+
+/// Arguments for building a permission claim transaction.
+pub struct PermissionSpendArgs<'a> {
+    /// Covenant ID identifying the rollup instance.
+    pub covenant_id: [u8; 32],
+    /// Outpoint of the permission UTXO to spend.
+    pub permission_outpoint: TransactionOutpoint,
+    /// Residual rent in sompis held by the permission UTXO.
+    pub permission_rent: u64,
+    /// Current Merkle root committed on-chain in the permission UTXO.
+    pub old_root: [u8; 32],
+    /// Current unclaimed exit count committed on-chain in the permission UTXO.
+    pub old_unclaimed: u64,
+    /// Merkle tree depth for the committed exit count.
+    pub depth: usize,
+    /// Index of the leaf being claimed.
+    pub leaf_index: usize,
+    /// Destination script public key bytes for the exit leaf payout.
+    pub leaf_spk: &'a [u8],
+    /// Exit payout amount currently recorded in the leaf.
+    pub leaf_amount: u64,
+    /// Amount in sompis to deduct from the leaf.
+    pub deduct: u64,
+    /// Merkle sibling hashes from leaf level to root for `leaf_index` against `old_root`.
+    pub siblings: Vec<[u8; 32]>,
+    /// Post-claim Merkle root derived by the caller.
+    pub new_root: [u8; 32],
+    /// Post-claim unclaimed exit count derived by the caller.
+    pub new_unclaimed: u64,
+    /// Delegate funding inputs paying into the spend and covering transaction fees.
+    pub delegate_inputs: Vec<(TransactionOutpoint, u64)>,
+    /// Transaction fee in sompis.
+    pub fee: u64,
+}
+
+/// Builds a permission spend transaction and its matched UTXO entries.
+pub fn build_permission_spend(
+    args: &PermissionSpendArgs<'_>,
+) -> Result<(Transaction, Vec<UtxoEntry>), &'static str> {
+    if args.deduct > args.leaf_amount {
+        return Err("deduct exceeds leaf amount");
+    }
+
+    let total_delegate: u64 = args.delegate_inputs.iter().map(|(_, a)| *a).sum();
+    if total_delegate + args.permission_rent < args.deduct + args.fee {
+        return Err("insufficient input value for deduct and fee");
+    }
+    if args.delegate_inputs.len() > MAX_DELEGATE_INPUTS {
+        return Err("too many delegate inputs");
+    }
+    if args.siblings.len() != args.depth {
+        return Err("siblings count does not match tree depth");
+    }
+
+    let is_done = args.new_unclaimed == 0;
+    let honest_out0 = if is_done { args.deduct + args.permission_rent } else { args.deduct };
+
+    let withdrawal_spk = ScriptPublicKey::new(0, args.leaf_spk.to_vec().into());
+    let mut outputs = vec![TransactionOutput::with_covenant(honest_out0, withdrawal_spk, None)];
+
+    let covenant_id = Hash::from_bytes(args.covenant_id);
+
+    if !is_done {
+        let new_redeem =
+            build_permission_redeem_script(&args.new_root, args.new_unclaimed, args.depth);
+        outputs.push(TransactionOutput::with_covenant(
+            args.permission_rent,
+            pay_to_script_hash_script(&new_redeem),
+            Some(CovenantBinding::new(0, covenant_id)),
+        ));
+    }
+
+    if total_delegate > args.deduct {
+        let delegate_change = total_delegate - args.deduct;
+        let delegate_redeem = build_delegate_entry_script(&args.covenant_id);
+        outputs.push(TransactionOutput::with_covenant(
+            delegate_change,
+            pay_to_script_hash_script(&delegate_redeem),
+            None,
+        ));
+    }
+
+    let old_redeem = build_permission_redeem_script(&args.old_root, args.old_unclaimed, args.depth);
+    let perm_sig = permission_sig_script(
+        args.leaf_spk,
+        args.leaf_amount,
+        args.deduct,
+        args.leaf_index,
+        &args.siblings,
+        &old_redeem,
+    );
+
+    let mut inputs = Vec::with_capacity(1 + args.delegate_inputs.len());
+    inputs.push(TransactionInput::new_with_compute_budget(
+        args.permission_outpoint,
+        perm_sig,
+        0,
+        0,
+    ));
+
+    let delegate_redeem = build_delegate_entry_script(&args.covenant_id);
+    let mut cov_b =
+        ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
+    let delegate_sig = cov_b.add_data(&delegate_redeem).unwrap().drain();
+
+    for &(outpoint, _) in &args.delegate_inputs {
+        inputs.push(TransactionInput::new_with_compute_budget(
+            outpoint,
+            delegate_sig.clone(),
+            0,
+            0,
+        ));
+    }
+
+    let tx =
+        Transaction::new(TX_VERSION_TOCCATA, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
+
+    let perm_spk = pay_to_script_hash_script(&old_redeem);
+    let mut utxos = Vec::with_capacity(1 + args.delegate_inputs.len());
+    utxos.push(UtxoEntry::new(args.permission_rent, perm_spk, 0, false, Some(covenant_id)));
+
+    let delegate_spk = pay_to_script_hash_script(&delegate_redeem);
+    for &(_, amount) in &args.delegate_inputs {
+        utxos.push(UtxoEntry::new(amount, delegate_spk.clone(), 0, false, None));
+    }
+
+    Ok((tx, utxos))
+}
+
+/// Computes sibling paths against the padded permission tree for a leaf index.
+pub fn claim_siblings(leaves: &[ExitLeaf], index: usize) -> Vec<[u8; 32]> {
+    let depth = PermissionTreeAccumulator::required_depth(leaves.len());
+    let capacity = 1usize << depth;
+    let empty = PermissionTreeAccumulator::hash_empty();
+    let mut level0 = vec![empty; capacity];
+    for (i, leaf) in leaves.iter().enumerate() {
+        level0[i] = PermissionTreeAccumulator::hash_leaf(leaf.to_standard_spk(), leaf.amount);
+    }
+    let mut nodes = vec![level0];
+    for _ in 0..depth {
+        let prev = nodes.last().unwrap();
+        let mut next = Vec::with_capacity(prev.len() / 2);
+        for i in 0..prev.len() / 2 {
+            next.push(PermissionTreeAccumulator::hash_branch(&prev[2 * i], &prev[2 * i + 1]));
+        }
+        nodes.push(next);
+    }
+    let mut out = Vec::with_capacity(depth);
+    let mut idx = index;
+    for level in 0..depth {
+        out.push(nodes[level][idx ^ 1]);
+        idx /= 2;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use kaspa_consensus_core::{
+        hashing::sighash::SigHashReusedValuesUnsync,
+        tx::{PopulatedTransaction, TransactionOutpoint},
+    };
+    use kaspa_hashes::Hash;
+    use kaspa_txscript::{
+        EngineFlags, TxScriptEngine, caches::Cache, covenants::CovenantsContext,
+        engine_context::EngineContext, script_builder::ScriptBuilder,
+        seq_commit_accessor::SeqCommitAccessor,
+    };
+    use vprogs_zk_abi::withdrawal::{ExitLeaf, StandardSpk};
+    use vprogs_zk_backend_risc0_api::{PermissionTreeAccumulator, build_permission_redeem_script};
+
+    use super::*;
+
+    struct NullAccessor;
+    impl SeqCommitAccessor for NullAccessor {
+        fn is_chain_ancestor_from_pov(&self, _: Hash) -> Option<bool> {
+            None
+        }
+        fn seq_commitment_within_depth(&self, _: Hash) -> Option<Hash> {
+            None
+        }
+    }
+
+    struct TestTree {
+        leaves: Vec<([u8; 34], u64)>,
+        depth: usize,
+        nodes: Vec<Vec<[u8; 32]>>,
+    }
+
+    impl TestTree {
+        fn new(leaves: Vec<([u8; 34], u64)>) -> Self {
+            let count = leaves.len();
+            let depth = PermissionTreeAccumulator::required_depth(count);
+            let mut t = Self { leaves, depth, nodes: Vec::new() };
+            t.rebuild();
+            t
+        }
+
+        fn rebuild(&mut self) {
+            let capacity = 1usize << self.depth;
+            let empty = PermissionTreeAccumulator::hash_empty();
+            let mut level0 = vec![empty; capacity];
+            for (i, (spk, amount)) in self.leaves.iter().enumerate() {
+                level0[i] = leaf_hash(spk, *amount);
+            }
+            let mut nodes = vec![level0];
+            for _ in 0..self.depth {
+                let prev = nodes.last().unwrap();
+                let mut next = Vec::with_capacity(prev.len() / 2);
+                for i in 0..prev.len() / 2 {
+                    next.push(PermissionTreeAccumulator::hash_branch(
+                        &prev[2 * i],
+                        &prev[2 * i + 1],
+                    ));
+                }
+                nodes.push(next);
+            }
+            self.nodes = nodes;
+        }
+
+        fn root(&self) -> [u8; 32] {
+            self.nodes[self.depth][0]
+        }
+
+        fn siblings(&self, index: usize) -> Vec<[u8; 32]> {
+            let mut out = Vec::with_capacity(self.depth);
+            let mut idx = index;
+            for level in 0..self.depth {
+                out.push(self.nodes[level][idx ^ 1]);
+                idx /= 2;
+            }
+            out
+        }
+
+        fn root_with_leaf(&self, index: usize, leaf: [u8; 32]) -> [u8; 32] {
+            let sibs = self.siblings(index);
+            let mut current = leaf;
+            for (level, sib) in sibs.iter().enumerate() {
+                if (index >> level) & 1 == 0 {
+                    current = PermissionTreeAccumulator::hash_branch(&current, sib);
+                } else {
+                    current = PermissionTreeAccumulator::hash_branch(sib, &current);
+                }
+            }
+            current
+        }
+    }
+
+    fn leaf_hash(spk: &[u8; 34], amount: u64) -> [u8; 32] {
+        let pk: &[u8; 32] = spk[1..33].try_into().unwrap();
+        PermissionTreeAccumulator::hash_leaf(StandardSpk::PubKey(pk), amount)
+    }
+
+    fn test_spk(seed: u8) -> [u8; 34] {
+        let pk = [seed; 32];
+        let bytes = StandardSpk::PubKey(&pk).to_script_bytes();
+        bytes.as_slice().try_into().unwrap()
+    }
+
+    fn cov_builder() -> ScriptBuilder {
+        ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
+    }
+
+    fn run_spend(tx: &Transaction, utxos: &[UtxoEntry]) -> Result<(), String> {
+        let sig_cache = Cache::new(10_000);
+        let reused = SigHashReusedValuesUnsync::new();
+        let flags = EngineFlags { covenants_enabled: true, ..Default::default() };
+        let populated = PopulatedTransaction::new(tx, utxos.to_vec());
+        let cov_ctx =
+            CovenantsContext::from_tx(&populated).expect("covenant continuity must succeed");
+        let accessor = NullAccessor;
+        let exec_ctx = EngineContext::new(&sig_cache)
+            .with_reused(&reused)
+            .with_seq_commit_accessor(&accessor)
+            .with_covenants_ctx(&cov_ctx);
+        let mut vm = TxScriptEngine::from_transaction_input(
+            &populated,
+            &tx.inputs[0],
+            0,
+            &utxos[0],
+            exec_ctx,
+            flags,
+        );
+        vm.execute().map_err(|e| format!("{e:?}"))
+    }
+
+    #[test]
+    fn builder_spend_passes_script_engine_partial_deduct() {
+        let spk = test_spk(1);
+        let leaves = vec![(spk, 5_000u64), (test_spk(2), 6_000)];
+        let tree = TestTree::new(leaves.clone());
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: tree.root(),
+            old_unclaimed: 2,
+            depth: tree.depth,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 5_000,
+            deduct: 2_000,
+            siblings: tree.siblings(0),
+            new_root: tree.root_with_leaf(0, leaf_hash(&spk, 5_000 - 2_000)),
+            new_unclaimed: 2,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 2_000)],
+            fee: 1_000,
+        };
+        let (tx, utxos) = build_permission_spend(&args).unwrap();
+        run_spend(&tx, &utxos).expect("partial deduct spend verifies");
+    }
+
+    #[test]
+    fn builder_full_claim_folds_rent_into_last_payout() {
+        let spk = test_spk(3);
+        let leaves = vec![(spk, 7_000u64)];
+        let tree = TestTree::new(leaves.clone());
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: tree.root(),
+            old_unclaimed: 1,
+            depth: tree.depth,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 7_000,
+            deduct: 7_000,
+            siblings: tree.siblings(0),
+            new_root: tree.root_with_leaf(0, PermissionTreeAccumulator::hash_empty()),
+            new_unclaimed: 0,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 7_000)],
+            fee: 1_000,
+        };
+        let (tx, utxos) = build_permission_spend(&args).unwrap();
+        run_spend(&tx, &utxos).expect("full claim verifies");
+    }
+
+    #[test]
+    fn sig_script_bytes_match_test_suite_layout() {
+        let spk = test_spk(4);
+        let leaves = vec![(spk, 100u64), (test_spk(5), 200)];
+        let tree = TestTree::new(leaves);
+        let redeem = build_permission_redeem_script(&tree.root(), 2, tree.depth);
+        let ours = permission_sig_script(&spk, 100, 40, 0, &tree.siblings(0), &redeem);
+        let mut b = cov_builder();
+        for level in (0..tree.depth).rev() {
+            b.add_data(&tree.siblings(0)[level]).unwrap();
+            b.add_i64(((0usize >> level) & 1) as i64).unwrap();
+        }
+        for level in (0..tree.depth).rev() {
+            b.add_data(&tree.siblings(0)[level]).unwrap();
+            b.add_i64(((0usize >> level) & 1) as i64).unwrap();
+        }
+        b.add_data(&spk).unwrap();
+        b.add_data(&100u64.to_le_bytes()).unwrap();
+        b.add_i64(40).unwrap();
+        b.add_data(&redeem).unwrap();
+        assert_eq!(ours, b.drain());
+    }
+
+    #[test]
+    fn claim_siblings_matches_tree_siblings() {
+        let pk_a = [0x11u8; 32];
+        let pk_b = [0x22u8; 32];
+        let spk_a = StandardSpk::PubKey(&pk_a);
+        let spk_b = StandardSpk::PubKey(&pk_b);
+        let leaves = vec![ExitLeaf::from_pair(spk_a, 100), ExitLeaf::from_pair(spk_b, 200)];
+        let tree_leaves = vec![
+            (spk_a.to_script_bytes().as_ref().try_into().unwrap(), 100u64),
+            (spk_b.to_script_bytes().as_ref().try_into().unwrap(), 200u64),
+        ];
+        let tree = TestTree::new(tree_leaves);
+        assert_eq!(claim_siblings(&leaves, 0), tree.siblings(0));
+        assert_eq!(claim_siblings(&leaves, 1), tree.siblings(1));
+    }
+
+    #[test]
+    fn builder_spend_with_delegate_change_passes_script_engine() {
+        let spk = test_spk(1);
+        let leaves = vec![(spk, 5_000u64), (test_spk(2), 6_000)];
+        let tree = TestTree::new(leaves.clone());
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: tree.root(),
+            old_unclaimed: 2,
+            depth: tree.depth,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 5_000,
+            deduct: 2_000,
+            siblings: tree.siblings(0),
+            new_root: tree.root_with_leaf(0, leaf_hash(&spk, 5_000 - 2_000)),
+            new_unclaimed: 2,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 3_000)],
+            fee: 1_000,
+        };
+        let (tx, utxos) = build_permission_spend(&args).unwrap();
+        // 3 outputs: payout (2000), continuation (50_000_000), delegate change (1000)
+        assert_eq!(tx.outputs.len(), 3);
+        assert_eq!(tx.outputs[2].value, 1_000);
+        run_spend(&tx, &utxos).expect("spend with delegate change verifies");
+    }
+
+    #[test]
+    fn builder_rejects_deduct_exceeding_leaf_amount() {
+        let spk = test_spk(6);
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: [0; 32],
+            old_unclaimed: 1,
+            depth: 1,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 5_000,
+            deduct: 6_000,
+            siblings: vec![[0; 32]],
+            new_root: [0; 32],
+            new_unclaimed: 0,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 6_000)],
+            fee: 1_000,
+        };
+        assert_eq!(build_permission_spend(&args).unwrap_err(), "deduct exceeds leaf amount");
+    }
+
+    #[test]
+    fn builder_rejects_insufficient_value() {
+        let spk = test_spk(7);
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: [0; 32],
+            old_unclaimed: 1,
+            depth: 1,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 5_000,
+            deduct: 2_000,
+            siblings: vec![[0; 32]],
+            new_root: [0; 32],
+            new_unclaimed: 1,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 1_000)],
+            fee: 50_000_000,
+        };
+        assert_eq!(
+            build_permission_spend(&args).unwrap_err(),
+            "insufficient input value for deduct and fee"
+        );
+    }
+}

--- a/zk/backend/risc0/app-kit/src/claim.rs
+++ b/zk/backend/risc0/app-kit/src/claim.rs
@@ -74,14 +74,13 @@ pub struct PermissionSpendArgs<'a> {
     pub new_root: [u8; 32],
     /// Post-claim unclaimed exit count derived by the caller.
     pub new_unclaimed: u64,
-    /// Delegate funding inputs paying into the spend and covering transaction fees.
+    /// Delegate funding inputs paying into the spend.
     pub delegate_inputs: Vec<(TransactionOutpoint, u64)>,
-    /// Transaction fee in sompis. Admission-only and not subtracted from outputs; built
-    /// transactions are zero-fee on-chain and may fail min-relay-fee policy outside simnet.
-    pub fee: u64,
 }
 
 /// Builds a permission spend transaction and its matched UTXO entries.
+///
+/// Built transactions are zero-fee on-chain; may fail min-relay-fee policy outside simnet.
 pub fn build_permission_spend(
     args: &PermissionSpendArgs<'_>,
 ) -> Result<(Transaction, Vec<UtxoEntry>), &'static str> {
@@ -354,7 +353,6 @@ mod tests {
             new_root: tree.root_with_leaf(0, leaf_hash(&spk, 5_000 - 2_000)),
             new_unclaimed: 2,
             delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 2_000)],
-            fee: 1_000,
         };
         let (tx, utxos) = build_permission_spend(&args).unwrap();
         run_spend(&tx, &utxos).expect("partial deduct spend verifies");
@@ -380,12 +378,42 @@ mod tests {
             new_root: tree.root_with_leaf(0, PermissionTreeAccumulator::hash_empty()),
             new_unclaimed: 0,
             delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 7_000)],
-            fee: 1_000,
         };
         let (tx, utxos) = build_permission_spend(&args).unwrap();
         assert_eq!(tx.outputs.len(), 1);
         assert_eq!(tx.outputs[0].value, 7_000 + 50_000_000);
         run_spend(&tx, &utxos).expect("full claim verifies");
+    }
+
+    #[test]
+    fn builder_full_claim_with_delegate_change_passes_script_engine() {
+        let spk = test_spk(3);
+        let leaves = vec![(spk, 7_000u64)];
+        let tree = TestTree::new(leaves.clone());
+        let args = PermissionSpendArgs {
+            covenant_id: [0xFF; 32],
+            permission_outpoint: TransactionOutpoint::new(Hash::from_u64_word(1), 0),
+            permission_rent: 50_000_000,
+            old_root: tree.root(),
+            old_unclaimed: 1,
+            depth: tree.depth,
+            leaf_index: 0,
+            leaf_spk: &spk,
+            leaf_amount: 7_000,
+            deduct: 7_000,
+            siblings: tree.siblings(0),
+            new_root: tree.root_with_leaf(0, PermissionTreeAccumulator::hash_empty()),
+            new_unclaimed: 0,
+            delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 10_000)],
+        };
+        let (tx, utxos) = build_permission_spend(&args).unwrap();
+        // 2 outputs: payout (7000 + 50_000_000 rent folded in) at index 0,
+        // delegate change (10_000 - 7_000 = 3_000) at index 1 (1 + CovOutCount where CovOutCount ==
+        // 0).
+        assert_eq!(tx.outputs.len(), 2);
+        assert_eq!(tx.outputs[0].value, 7_000 + 50_000_000);
+        assert_eq!(tx.outputs[1].value, 3_000);
+        run_spend(&tx, &utxos).expect("full claim with delegate change verifies");
     }
 
     #[test]
@@ -447,7 +475,6 @@ mod tests {
             new_root: tree.root_with_leaf(0, leaf_hash(&spk, 5_000 - 2_000)),
             new_unclaimed: 2,
             delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 3_000)],
-            fee: 1_000,
         };
         let (tx, utxos) = build_permission_spend(&args).unwrap();
         // 3 outputs: payout (2000), continuation (50_000_000), delegate change (1000)
@@ -474,7 +501,6 @@ mod tests {
             new_root: [0; 32],
             new_unclaimed: 0,
             delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 6_000)],
-            fee: 1_000,
         };
         assert_eq!(build_permission_spend(&args).unwrap_err(), "deduct exceeds leaf amount");
     }
@@ -497,7 +523,6 @@ mod tests {
             new_root: [0; 32],
             new_unclaimed: 1,
             delegate_inputs: vec![(TransactionOutpoint::new(Hash::from_u64_word(2), 1), 1_500)],
-            fee: 0,
         };
         assert_eq!(
             build_permission_spend(&args).unwrap_err(),

--- a/zk/backend/risc0/app-kit/src/lib.rs
+++ b/zk/backend/risc0/app-kit/src/lib.rs
@@ -1,11 +1,15 @@
 //! Host-side issuer kit over the runtime battery and the L1 wallet: lane-payload
 //! assembly, carrier composition, submit retries; the runner stays issuer-free.
 
+pub mod claim;
 pub mod genesis;
 pub mod lane;
 pub mod payload;
 pub mod signer;
 
+pub use claim::{
+    PermissionSpendArgs, build_permission_spend, claim_siblings, permission_sig_script,
+};
 pub use genesis::{dev_genesis_keypair, p2pk_address};
 pub use lane::{
     CarrierTxArgs, DEFAULT_MAX_SUBMIT_ATTEMPTS, DEFAULT_SUBMIT_RETRY_DELAY,


### PR DESCRIPTION
Host-side claim kit for settled exits: zk-abi `ExitLeaf`, per-bundle exit leaf publication by the aggregate prover, and `app-kit/claim.rs` building permission-spend transactions over the padded Merkle tree.

## zk-abi: ExitLeaf

`zk/abi/src/withdrawal/exit_leaf.rs` — owned mirror of `StandardSpk` scoped to host channels (not a generic type): carries `spk`, `amount`, `deduct`. `from_script` replaces an unworkable decode sketch; round-trip tests cover the struct layout. `StandardSpk` gains a byte-tagging scheme used by the extraction loop.

## aggregate-prover: per-bundle exit leaves

`exit_feed.rs` — extracts exit leaves from each bundle's journal and forwards them over a new per-bundle mpsc `ExitsForBundle` channel on `RunnerHandles` (exits are per-event data: a watch would coalesce intermediate bundles away unrecoverably; the `settlement` watch stays latest-wins because `SettlementInfo` is cumulative). `worker.rs` publishes after the bundle is proved and before settlement. `AggregateProverConfig` grows an optional `exits` sender; journals collected unconditionally on observer presence.

## runner: RunnerHandles.exits_rx

Thin plumbing in `start.rs`/`node.rs` threading the exits channel through `NodeConfig` and out of `start_runner`. `sim/src/driver/l2_driver.rs:255` still hardcodes `exits: None` — the driver e2e claim step threads it in during the web-demo stage.

## app-kit: claim.rs

`zk/backend/risc0/app-kit/src/claim.rs`:

- `PermissionSpendArgs` — collects the permission UTXO, program covenant, sibling path, and deduction amounts needed to build one claim input; `fee` field removed (never read — the sig script pins outputs directly; min-relay note on the fn doc).
- `build_permission_spend(args) -> Result<(Transaction, Vec<UtxoEntry>), &'static str>` — assembles the permission-spend transaction and fails on over-deduct.
- `permission_sig_script(args)` — the permission spend's input script: `ExitLeaf` serialization → `fold_path` accumulator → `OP_1` covenant witness.
- `claim_siblings(tree_view, leaf_idx)` — extracts the Merkle sibling path for a given leaf from the padded tree view.
- Conservation check replaced by the on-chain invariant `total_delegate >= deduct` (rent-bridging admits consensus-invalid txs under the original stricter formula).

## Tests

Script-engine-verified spend builds: partial deduct, full claim with rent fold-in, delegate-change output; sig-script layout pinned against the test suite; decode round-trips. Gates: `cargo-fmt-all.sh` + `RUSTC_WRAPPER= cargo test --workspace`.

## Stack position

Sits on `indexer-hook` (resource indexer hooks). `exit-index` follows.
