### PR TITLE
bridge-lane-anchor bridge: anchor first lane activation at the parent seq commit

### DIFF
--- a/l1/bridge/src/worker.rs
+++ b/l1/bridge/src/worker.rs
@@ -566,9 +566,17 @@ impl<T: ChainSink<ChainBlockMetadata, L1Transaction>> BridgeWorker<T> {
         txs: &[SchedulerTransaction<L1Transaction>],
         block: &ChainBlockMetadata,
     ) -> (Hash, u64, bool) {
-        // Check whether the lane has gone silent past the finality window and needs to reset.
+        // Consensus anchors a lane re-activation at `parent.seq_commit` whenever the lane holds no
+        // live SMT entry at the parent: on the first activation (nothing folded into the lane yet,
+        // `lane_blue_score` still at its zero seed) or after going silent past the finality window.
+        // The gap check alone never trips before the first activation under a real finality depth,
+        // so the zero seed would anchor the lane and every derived tip would diverge from
+        // consensus. A bridge joining an already-live lane still needs the authoritative tip seeded
+        // from `get_seq_commit_lane_proof` at startup; until then only lanes born after the bridge
+        // start derive correctly.
         let blue_score = block.blue_score;
-        let lane_expired = blue_score.saturating_sub(parent.lane_blue_score) > self.finality_depth;
+        let lane_expired = parent.lane_blue_score == 0
+            || blue_score.saturating_sub(parent.lane_blue_score) > self.finality_depth;
 
         // No lane configured or no activity this block -> carry parent state forward unchanged.
         let Some(lane_key) = self.lane_key.as_ref().filter(|_| !txs.is_empty()) else {

--- a/runner/tests/two_provers_contend.rs
+++ b/runner/tests/two_provers_contend.rs
@@ -67,19 +67,6 @@ const COVENANT_VALUE: u64 = SOMPI_PER_KASPA;
 /// lane_key match (see the e2e test's `L2_LANE_SUBNET` doc for the divergence this avoids).
 const LANE_SUBNET: SubnetworkId = TEST_SUBNETWORK_ID;
 
-/// Bridge lane-finality window. Consensus only falls back to the parent block's `seq_commit`
-/// (rather than the lane tip) as the lane parent-ref when the lane has no live SMT entry: on its
-/// FIRST activation, or after it has gone silent past the real finality window (~432k blocks, never
-/// reached in a test). The bridge models "no live entry" as `blue_score - parent.lane_blue_score >
-/// finality_depth`. With the real simnet finality_depth the first activation never trips that
-/// bound, so the bridge would pick the zero parent lane tip while consensus picks the parent
-/// seq_commit, and the guest's committed `new_seq_commit` diverges from the chain's
-/// `accepted_id_merkle_root`. A small window fixes this: the first carrier's blue score is well
-/// above it (parent `lane_blue_score` is 0, so first activation expires → seq_commit, matching
-/// consensus), while consecutive carriers stay within it (gap ~2 blue score → lane alive → lane
-/// tip, matching consensus, which never expires a re-touched lane in-test).
-const LANE_FINALITY_DEPTH: u64 = 10;
-
 /// Sompi each funding output carries, and how many each prover address is seeded with. A prover's
 /// settler funds every settlement fee from its own address, so it needs several spendable UTXOs to
 /// fund a chain of settlements under contention.
@@ -1566,7 +1553,7 @@ async fn spawn_prover(
             network_id,
             lane_subnet: LANE_SUBNET,
             covenant_id,
-            finality_depth: LANE_FINALITY_DEPTH,
+            finality_depth: params.finality_depth(),
             seed_depth: 0,
             min_confirmations: None,
             start_from,


### PR DESCRIPTION
Bridge lane anchoring fixed to match consensus: a lane holding no live SMT entry at the parent - first activation included - anchors at `parent.seq_commit`, not the zero seed. This was the defect behind every runner-driven settlement rejection since the simnet finality depth went real.

## Symptom

Settlements submitted by the runner were rejected by the node at script verification; the divergence was pinned in debug at `zk/aggregate-prover/src/worker.rs` (`debug_assert_eq!(st.new_seq_commit, last_metadata.seq_commit)`): the aggregator guest's derived `new_seq_commit` did not equal the block header's `accepted_id_merkle_root`.

## Mechanism

The bridge derives each chain block's lane tip in `lane_state()`. Consensus (`resolve_lane_updates` in rusty-kaspa) anchors a lane with no live SMT entry at the parent at `parent.seq_commit` - true both on the lane's first activation and after silence past the finality window. The bridge only took that branch on the silence clause (`gap > finality_depth`), which can never fire before the first activation under real finality depths (432k blue score on simnet): `parent.lane_blue_score` sits at its zero seed and the gap is tiny. So the first carrier anchored the lane at the zero seed, and every subsequent derived lane tip - and thus the settled root - diverged from consensus.

## Fix

Treat the never-activated seed (`lane_blue_score == 0`) as no live entry, alongside the silence clause. The sim driver already special-cases first activation the same way (`sim/src/driver/l2_driver.rs:420-427` documents the identical rule).

`two_provers_contend` only ever passed because it shrank the bridge finality window to `LANE_FINALITY_DEPTH = 10`, making first activation trip the silence clause by construction; that workaround is removed and the test now runs the bridge at `params.finality_depth()`, making it the integration regression for this fix.

## Ceiling

A bridge joining an already-live lane still mis-anchors (its first observation is not the lane's first activation) until authoritative tip seeding from `get_seq_commit_lane_proof` at startup lands. Deployments that always start bridges before their covenants go live - the demo, the sim - are unaffected.

## Tests

New unit test `lane_state_anchors_first_activation_and_reactivation_at_seq_commit` (first activation / live lane / re-activation after silence), plus `two_provers_contend` at real finality depth under `RISC0_DEV_MODE=1`. Gates: `cargo-fmt-all.sh`, bridge lib tests.

## Stack position

Sits on `claim-kit` (claim kit for settled exits). `exit-index` is rebased on top.
